### PR TITLE
docs: move Platforms section to docs

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -1,0 +1,18 @@
+# Platforms Guide
+
+## Android
+
+Set `ANDROID_NDK_HOME` and run:
+
+```bash
+export ANDROID_NDK_HOME=/path/to/ndk
+cmake --workflow --preset=android-arm64-full
+```
+
+## Cross-Compilation (Linux → Windows)
+
+Requires [llvm-mingw](https://github.com/mstorsjo/llvm-mingw) on `PATH`:
+
+```bash
+cmake --workflow --preset=llvm-mingw-x86_64-full
+```


### PR DESCRIPTION
## What this PR does
- Moved Android and cross-compilation sections from README to docs/platforms.md
- Updated README links

Related to #4