### PR TITLE
feat: add Dependabot and Renovate configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+version: 2
+
+updates:
+  # ─── GitHub Actions ────────────────────────────────────────────────────────
+  # Keep CI/CD actions up to date (checkout, setup-python, cache, upload-artifact, etc.)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # ─── CPM (CMake Package Manager) dependencies ─────────────────────────────
+  # CPM deps are declared in cmake/cpm/*.cmake via cpmaddpackage() with GIT_TAG.
+  # Dependabot does not natively support CPM, so we use Renovate for CPM packages.
+  # See .github/renovate.json5 for CPM dependency management.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,152 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  extends: [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticPrefixFixDepsChoreOthers",
+    "group:monorepos",
+    "helpers:pinGitHubActionDigests"
+  ],
+
+  // ─── General ──────────────────────────────────────────────────────────────
+  timezone: "UTC",
+  schedule: ["before 8am on monday"],
+  prConcurrentLimit: 10,
+  prHourlyLimit: 3,
+  labels: ["dependencies"],
+  commitMessagePrefix: "chore(deps):",
+  commitMessageAction: "update",
+  commitMessageTopic: "{{depName}}",
+  commitMessageExtra: "to {{newValue}}",
+
+  // ─── Vulnerability alerts ─────────────────────────────────────────────────
+  vulnerabilityAlerts: {
+    enabled: true,
+    schedule: ["at any time"],
+    labels: ["dependencies", "security"]
+  },
+
+  // ─── GitHub Actions ───────────────────────────────────────────────────────
+  // Covers .github/workflows/*.yml — checkout, setup-python, cache,
+  // upload-artifact, download-artifact, etc.
+  "github-actions": {
+    enabled: true
+  },
+  packageRules: [
+    {
+      description: "Group all GitHub Actions bumps into one PR",
+      matchManagers: ["github-actions"],
+      groupName: "github-actions",
+      labels: ["dependencies", "github-actions"]
+    },
+    {
+      description: "Auto-merge patch and pin updates after CI passes",
+      matchUpdateTypes: ["patch", "pin"],
+      automerge: true,
+      automergeStrategy: "squash",
+      platformAutomerge: true
+    }
+  ],
+
+  // ─── CPM (CMake Package Manager) ──────────────────────────────────────────
+  // CPM deps live in cmake/cpm/*.cmake via cpmaddpackage() calls.
+  // Renovate has no native CPM manager, so we use regex customManagers.
+  //
+  // Tracked dependencies:
+  //   cpm          cpm-cmake/CPM.cmake              (version var)
+  //   doctest      doctest/doctest                  (GIT_TAG)
+  //   entt         skypjack/entt                    (GIT_TAG)
+  //   fastgltf     spnda/fastgltf                   (GIT_TAG)
+  //   flecs        SanderMertens/flecs              (GIT_TAG)
+  //   freetype     freetype/freetype                VER-2-14-3 (GIT_TAG)
+  //   glm          g-truc/glm                       (GIT_TAG)
+  //   gsl          microsoft/GSL                    (GIT_TAG)
+  //   imgui        ocornut/imgui                    (VERSION)
+  //   implot       epezent/implot                   (GIT_TAG)
+  //   lua          lua/lua                          (VERSION)
+  //   pybind       pybind/pybind11                  (GIT_TAG)
+  //   safetyhook   cursey/safetyhook                (GIT_TAG)
+  //   sdl3         libsdl-org/SDL                   (GIT_TAG)
+  //   sdl3_mixer   libsdl-org/SDL_mixer             (GIT_TAG)
+  //   shadercross  libsdl-org/shadercross           (GIT_TAG)
+  //   spdlog       gabime/spdlog                    (GIT_TAG)
+  //   stb          nothings/stb                     (GIT_TAG)
+  //   steam_audio  ValveSoftware/steam-audio        (GIT_TAG)
+  //   tinygltf     syoyo/tinygltf                   (GIT_TAG)
+  //   tinyobjloader syoyo/tinyobjloader             (GIT_TAG)
+  //   tracy        wolfpld/tracy                    (GIT_TAG)
+  //   yaml-cpp     jbeder/yaml-cpp                  (GIT_TAG)
+  customManagers: [
+    // ── CPM version variable (cpm-config.cmake) ─────────────────────────────
+    // Matches: set(cpm_version "0.42.3")
+    // followed by a FetchContent URL referencing cpm-cmake/CPM.cmake
+    {
+      customType: "regex",
+      description: "Update CPM.cmake version variable",
+      managerFilePatterns: ["/(^|/)cpm-config\\.cmake$/"],
+      matchStrings: [
+        "set\\(cpm_version\\s+\"(?<currentValue>[^\"]+)\"\\)"
+      ],
+      depNameTemplate: "cpm-cmake/CPM.cmake",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^v?(?<version>.+)$"
+    },
+
+    // ── CPM packages with GIT_TAG (version tags, not SHAs) ──────────────────
+    // Matches: GIT_TAG v1.17.0 / GIT_TAG 1.0.3 / GIT_TAG VER-2-14-3
+    // paired with: GIT_REPOSITORY https://github.com/owner/repo
+    //
+    // Handles both orderings (GIT_TAG before GIT_REPOSITORY and vice versa).
+    // Excludes pure hex SHAs (5-40 chars) — those are handled by the digest manager.
+    {
+      customType: "regex",
+      description: "Update CPM deps pinned by GIT_TAG (version tags)",
+      managerFilePatterns: ["/(^|/)cmake/cpm/[^/]+-config\\.cmake$/"],
+      matchStrings: [
+        // GIT_TAG before GIT_REPOSITORY
+        "GIT_TAG\\s+(?<currentValue>v?[A-Za-z]*\\d[^\\s\"]*?)\\s+GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s",
+        // GIT_REPOSITORY before GIT_TAG
+        "GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s+GIT_TAG\\s+(?<currentValue>v?[A-Za-z]*\\d[^\\s\"]*?)\\s"
+      ],
+      datasourceTemplate: "github-tags",
+      extractVersionTemplate: "^(?:v|VER-)?(?<version>.+)$"
+    },
+
+    // ── CPM packages with VERSION only (implies GIT_TAG v{VERSION}) ─────────
+    // Matches: VERSION 1.92.8  paired with GIT_REPOSITORY
+    // Used by: imgui, lua
+    {
+      customType: "regex",
+      description: "Update CPM deps pinned by VERSION field",
+      managerFilePatterns: ["/(^|/)cmake/cpm/[^/]+-config\\.cmake$/"],
+      matchStrings: [
+        // VERSION before GIT_REPOSITORY
+        "VERSION\\s+(?<currentValue>\\d[^\\s\"]*?)\\s+GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s",
+        // GIT_REPOSITORY before VERSION
+        "GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s+VERSION\\s+(?<currentValue>\\d[^\\s\"]*?)\\s"
+      ],
+      datasourceTemplate: "github-tags",
+      extractVersionTemplate: "^v?(?<version>.+)$"
+    },
+
+    // ── CPM packages pinned to commit SHA ───────────────────────────────────
+    // Matches: GIT_TAG 7bddff8c01f5fb931c3cb73d4aa8e66d303d97bc
+    // paired with: GIT_REPOSITORY https://github.com/owner/repo
+    // Uses git-refs datasource to track the default branch HEAD.
+    {
+      customType: "regex",
+      description: "Update CPM deps pinned to commit SHA",
+      managerFilePatterns: ["/(^|/)cmake/cpm/[^/]+-config\\.cmake$/"],
+      matchStrings: [
+        // GIT_TAG (SHA) before GIT_REPOSITORY
+        "GIT_TAG\\s+(?<currentDigest>[0-9a-f]{7,40})\\s+GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s",
+        // GIT_REPOSITORY before GIT_TAG (SHA)
+        "GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\\s+GIT_TAG\\s+(?<currentDigest>[0-9a-f]{7,40})\\s"
+      ],
+      datasourceTemplate: "git-refs",
+      depNameTemplate: "https://github.com/{{{depName}}}.git",
+      currentValueTemplate: "main"
+    }
+  ]
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,63 @@
+name: Renovate
+
+on:
+  # Manual trigger from GitHub UI
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Dry run (no PRs created)'
+        required: false
+        default: false
+        type: boolean
+      logLevel:
+        description: 'Log level'
+        required: false
+        default: info
+        type: choice
+        options:
+          - debug
+          - info
+          - warn
+          - error
+
+  # Schedule: weekly on Monday at 6am UTC
+  schedule:
+    - cron: '0 6 * * 1'
+
+  # Also run on pushes to main that touch renovate config
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/renovate.json5'
+      - '.github/workflows/renovate.yml'
+
+concurrency:
+  group: renovate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v40.3.6
+        with:
+          configurationFile: .github/renovate.json5
+          token: ${{ secrets.RENOVATE_TOKEN || secrets.GITHUB_TOKEN }}
+        env:
+          RENOVATE_DRY_RUN: ${{ github.event.inputs.dryRun || 'false' }}
+          LOG_LEVEL: ${{ github.event.inputs.logLevel || 'info' }}
+          # Tell Renovate which repository to process
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # Free tier optimizations
+          RENOVATE_PLATFORM_COMMIT: true
+          RENOVATE_AUTODISCOVER: false
+          RENOVATE_ONBOARDING: false


### PR DESCRIPTION
## Summary

Adds dependency management configurations copied from [airstrike3d-tools](https://github.com/e-gleba/airstrike3d-tools):

| File | Purpose |
|------|---------|
| `.github/dependabot.yml` | GitHub Actions updates (weekly) |
| `.github/renovate.json5` | CPM dependency management |
| `.github/workflows/renovate.yml` | Free-tier Renovate workflow |

## CPM Dependencies Tracked

20+ packages including:
- `doctest`, `entt`, `fastgltf`, `flecs`, `freetype`
- `glm`, `gsl`, `imgui`, `implot`, `lua`
- `pybind`, `safetyhook`, `sdl3`, `sdl3_mixer`, `shadercross`
- `spdlog`, `stb`, `steam_audio`, `tinygltf`, `tinyobjloader`
- `tracy`, `yaml-cpp`

## Usage

1. **Dependabot**: Runs automatically (weekly)
2. **Renovate**: 
   - Manual: Actions → Renovate → Run workflow
   - Scheduled: Weekly (Monday 6am UTC)
   - Auto: On config changes

## Free Tier

Uses `GITHUB_TOKEN` — no paid Renovate app needed. Add `RENOVATE_TOKEN` secret for higher rate limits if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency monitoring for GitHub Actions and CMake packages.
  * Scheduled regular dependency update checks and vulnerability alerts.
  * Grouped related updates to simplify maintenance.

* **Bug Fixes**
  * Enabled automatic patch and pin updates after successful CI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->