### PR TITLE
fix(ci): pin windows-2022 runner for VS 2022 compatibility

### DIFF
--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -51,7 +51,7 @@ jobs:
                     - os: ubuntu-latest
                       preset: gcc-full
                       artifact-name: linux-gcc
-                    - os: windows-latest
+                    - os: windows-2022  # Pin to windows-2022 for VS 2022
                       preset: msvc-full
                       artifact-name: windows-msvc
 


### PR DESCRIPTION
## Problem

Windows builds failing with:
```
CMake Error at CMakeLists.txt:3 (project):
  Generator
    Visual Studio 17 2022
  could not find any instance of Visual Studio.
```

## Root Cause

`windows-latest` now points to **Windows Server 2025** which doesn't include Visual Studio 2022. Your `CMakePresets.json` specifies `"generator": "Visual Studio 17 2022"`.

## Fix

Pin runner to `windows-2022`:
```yaml
- os: windows-2022  # was: windows-latest
  preset: msvc-full
  artifact-name: windows-msvc
```

## References

- [GitHub runner-images #12113](https://github.com/actions/runner-images/issues/12113)
- [Windows Server 2025 image changes](https://github.blog/changelog/2025-07-15-github-actions-windows-server-2025-is-now-available/)

## Alternative (Future)

If you want to use `windows-latest` later, update `CMakePresets.json`:
```json
"generator": "Visual Studio 18 2026"
```