### PR TITLE
feat(deps): replace sol2 with LuaBridge3

### DIFF
--- a/cmake/cpm/lua_lang-config.cmake
+++ b/cmake/cpm/lua_lang-config.cmake
@@ -1,12 +1,10 @@
 cpmaddpackage(
     NAME
     lua
-    GITHUB_REPOSITORY
-    lua/lua
+    GIT_REPOSITORY
+    https://github.com/lua/lua.git
     VERSION
     5.5.0
-    EXCLUDE_FROM_ALL
-    ON
     DOWNLOAD_ONLY
     YES)
 
@@ -15,41 +13,32 @@ if(lua_ADDED)
         GLOB
         lua_sources
         CONFIGURE_DEPENDS
-        ${lua_SOURCE_DIR}/*.c)
+        "${lua_SOURCE_DIR}/*.c")
     list(
         REMOVE_ITEM
         lua_sources
-        "${lua_SOURCE_DIR}/lua.c"
-        "${lua_SOURCE_DIR}/luac.c"
-        "${lua_SOURCE_DIR}/onelua.c")
+        "${lua_SOURCE_DIR}/lua.c" # Interpreter
+        "${lua_SOURCE_DIR}/luac.c" # Compiler
+        "${lua_SOURCE_DIR}/onelua.c" # Single-file build
+    )
+
     add_library(lua STATIC ${lua_sources})
-    target_include_directories(lua PUBLIC $<BUILD_INTERFACE:${lua_SOURCE_DIR}>)
-    # Build as C
-    set_target_properties(lua PROPERTIES LINKER_LANGUAGE C)
-endif()
+    add_library(lua::lua ALIAS lua)
 
-option(SOL2_PATCHED "whether sol2 patch has been applied" OFF)
+    target_include_directories(lua SYSTEM
+                               PUBLIC "$<BUILD_INTERFACE:${lua_SOURCE_DIR}>")
 
-if(NOT SOL2_PATCHED)
-    set(SOL2_PATCHED
-        ON
-        CACHE BOOL "whether sol2 patch has been applied" FORCE)
+    target_compile_features(lua PUBLIC c_std_23)
 
-    cpmaddpackage(
-        NAME
-        sol2
-        GIT_REPOSITORY
-        https://github.com/ThePhD/sol2.git
-        VERSION
-        3.3.0
-        PATCHES
-        "${CMAKE_SOURCE_DIR}/cmake/patches/sol2_emplace_fix.patch")
-else()
-    cpmaddpackage(
-        NAME
-        sol2
-        GIT_REPOSITORY
-        https://github.com/ThePhD/sol2.git
-        VERSION
-        3.3.0)
+    # Professional Lua configuration
+    target_compile_definitions(
+        lua
+        PUBLIC LUA_COMPAT_5_3=0 # Disable Lua 5.3 compatibility bloat
+               $<$<CONFIG:Debug>:LUA_USE_APICHECK> # API checking in debug only
+    )
+
+    # Performance: computed goto (GCC/Clang only)
+    if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_definitions(lua PRIVATE LUA_USE_JUMPTABLE)
+    endif()
 endif()

--- a/cmake/cpm/luabridge3-config.cmake
+++ b/cmake/cpm/luabridge3-config.cmake
@@ -1,0 +1,14 @@
+# LuaBridge3 — lightweight C++ Lua binding
+# https://github.com/kunitoki/LuaBridge3
+
+cpmaddpackage(
+    NAME
+    LuaBridge3
+    GIT_TAG
+    3.0-rc12
+    GIT_REPOSITORY
+    https://github.com/kunitoki/LuaBridge3
+    EXCLUDE_FROM_ALL
+    YES
+    SYSTEM
+    YES)


### PR DESCRIPTION
# Pull Request

## Summary
Replace sol2 with LuaBridge3 for Lua C++ bindings, porting the proven CPM setup from airstrike3d-tools.

## Related Issue
No issue — catalog dep swap.

## Changes
- `cmake/cpm/lua_lang-config.cmake` — drop sol2 + `SOL2_PATCHED` / emplace patch. Keep Lua 5.5.0 as a static lib (`lua` / `lua::lua`), SYSTEM includes, `c_std_23`, `LUA_COMPAT_5_3=0`, debug `LUA_USE_APICHECK`, GCC/Clang `LUA_USE_JUMPTABLE`.
- `cmake/cpm/luabridge3-config.cmake` — new. CPM `kunitoki/LuaBridge3` @ `3.0-rc12`, `EXCLUDE_FROM_ALL` + `SYSTEM`. Exports INTERFACE target `LuaBridge`.

Catalog-only. Neither package is `find_package`'d from `cpm-config.cmake`, so default configure/build is unchanged. Consume later with:

```cmake
find_package(lua_lang CONFIG REQUIRED)
find_package(luabridge3 CONFIG REQUIRED)
# then: target_link_libraries(<tgt> PRIVATE lua LuaBridge)
```

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed

Config files only — no src/test/preset/docker change. Default CI path does not fetch lua/LuaBridge3.

## Notes for Reviewer
Source of truth: [e-gleba/airstrike3d-tools](https://github.com/e-gleba/airstrike3d-tools) `cmake/cpm/lua_lang-config.cmake` + `cmake/cpm/luabridge3-config.cmake` (user path `lua_lang.cmake` is that file).

LuaBridge3 is header-only INTERFACE. Link both `lua` and `LuaBridge`. Tests stay off via `EXCLUDE_FROM_ALL` (LuaBridge3 only builds tests when it is the top-level project).

Left untouched on purpose (`docs/references.md` still lists sol2, renovate comment catalog). Say if those should follow.