### PR TITLE
feat(ci): post-release CMake version bump via PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,10 @@
 #   docker    → reusable publish-docker.yml  (optional, matrix per image)
 #   packages  → reusable cmake_multi_platform.yml (native / cross / android)
 #   publish   → tag + gh release, attach CPack/APK artifacts from `packages`
+#   bump      → after publish: PR that bumps project(VERSION) on main, then merge
 #
 # Adapt:
-#   - version is an input — never hardcoded
+#   - version / next_version are inputs — never hardcoded
 #   - add/remove docker images in publish-docker.yml matrix
 #   - add package globs in the "Collect release assets" step if you add formats
 #   - permissions below are the union of what the called workflows need
@@ -19,6 +20,10 @@ on:
     inputs:
       version:
         description: "Release tag (e.g. v1.0.0)"
+        required: true
+        type: string
+      next_version:
+        description: "Next CMake project() VERSION, no v prefix (e.g. 1.0.1) — bot opens+merges a PR after the release"
         required: true
         type: string
       prerelease:
@@ -42,6 +47,7 @@ permissions:
   actions: read
   id-token: write
   attestations: write
+  pull-requests: write
 
 jobs:
   docker:
@@ -130,3 +136,98 @@ jobs:
           gh release create "${args[@]}" "${files[@]}"
           echo "Created ${{ github.server_url }}/${{ github.repository }}/releases/tag/${VERSION}" \
             >> "$GITHUB_STEP_SUMMARY"
+
+  # After the tag+artifacts exist. Does not rewrite the just-shipped
+  # project(VERSION) — packages always match their own tag. Prepares
+  # main for the NEXT release via a PR (not a direct push to main).
+  bump_cmake_version:
+    name: bump cmake version via pr
+    needs: publish
+    if: >-
+      !cancelled()
+      && needs.publish.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    # Two release runs must never race the bump PR:
+    # queue the jobs, never cancel them mid-push.
+    concurrency:
+      group: post-release-cmake-version-bump
+      cancel-in-progress: false
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Bound once via env — never expand a workflow input into shell
+      # source (zizmor template-injection).
+      NEXT_VERSION: ${{ inputs.next_version }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate next_version
+        run: |
+          if [[ ! "${NEXT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            printf "::error::next_version must be plain semver, no v prefix (e.g. 1.0.1) — got '%s'\n" "${NEXT_VERSION}"
+            exit 1
+          fi
+          current=$(grep -E '^[[:space:]]*VERSION[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*$' CMakeLists.txt | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+          if [[ -z "${current}" ]]; then
+            echo "::error::could not read the current project version from CMakeLists.txt"
+            exit 1
+          fi
+          # sort -V: smaller of the two sorts first, so an equal or
+          # lower next_version sorts first — reject both.
+          lowest=$(printf '%s\n%s\n' "${current}" "${NEXT_VERSION}" | sort -V | head -n1)
+          if [[ "${lowest}" == "${NEXT_VERSION}" ]]; then
+            printf "::error::next_version (%s) must be greater than the current project version (%s)\n" "${NEXT_VERSION}" "${current}"
+            exit 1
+          fi
+          echo "current=${current}" >> "${GITHUB_ENV}"
+          echo "Bumping project(VERSION) ${current} → ${NEXT_VERSION} (release ${VERSION})"
+
+      - name: Bump project version
+        run: |
+          sed -i -E "s/^([[:space:]]*VERSION[[:space:]]+)[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*$/\1${NEXT_VERSION}/" CMakeLists.txt
+          grep -E "^[[:space:]]*VERSION[[:space:]]+${NEXT_VERSION}[[:space:]]*$" CMakeLists.txt
+
+      - name: Open and merge bump PR
+        run: |
+          branch="chore/bump-cmake-version-${NEXT_VERSION}-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${branch}"
+          git add CMakeLists.txt
+          git commit -m "chore: bump CMake project version to ${NEXT_VERSION}"
+          git push origin "HEAD:${branch}"
+
+          pr_url=$(gh pr create \
+            --base main \
+            --head "${branch}" \
+            --title "chore: bump CMake project version to ${NEXT_VERSION}" \
+            --body "$(cat <<EOF
+          Post-release bump. Tag \`${VERSION}\` already published with \`project(VERSION)\` ${current}.
+
+          Prepares main for the next release so packages always ship the version of their own tag.
+
+          - \`CMakeLists.txt\` \`project(VERSION)\`: ${current} → ${NEXT_VERSION}
+
+          Opened by the [release workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          EOF
+          )")
+
+          echo "Opened ${pr_url}" >> "${GITHUB_STEP_SUMMARY}"
+
+          # Leave the PR open if merge is blocked (reviews / checks).
+          # Settings → Actions → General → "Allow GitHub Actions to create
+          # and approve pull requests" must be on, or gh pr create fails.
+          if gh pr merge --squash --delete-branch; then
+            echo "Merged ${pr_url}" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "::warning::could not merge ${pr_url} — merge it manually"
+            echo "Merge blocked — merge ${pr_url} manually" >> "${GITHUB_STEP_SUMMARY}"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file helps AI assistants (Claude, Cursor, Copilot) understand the project c
 - **Package Manager**: CPM.cmake (CMake-based, no external package manager like Conan/vcpkg yet)
 - **Test Framework**: doctest + CTest presets
 - **CI**: GitHub Actions (`cmake_multi_platform.yml`, reusable)
-- **Release**: `release.yml` (dispatch) pipes CI + optional `publish-docker.yml`
+- **Release**: `release.yml` (dispatch: `version` + `next_version`) pipes CI + optional `publish-docker.yml`, then a post-release PR that bumps `project(VERSION)` on main
 - **Docker**: Official-base toolchain images in `docker/` (no source COPY)
 
 ## Directory Layout Rules
@@ -89,7 +89,7 @@ cmake --build build/gcc --target cpplint  # cppcheck/cpplint
 
 - Every workflow file starts with `# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json`.
 - Build matrix lives in `.github/workflows/cmake_multi_platform.yml` (`workflow_call` so `release.yml` can reuse it). Do not duplicate jobs.
-- Release is `.github/workflows/release.yml` (`workflow_dispatch`, version input). It pipes `publish-docker.yml` + the multi-platform workflow, then `gh release create`.
+- Release is `.github/workflows/release.yml` (`workflow_dispatch`, `version` + `next_version` inputs). It pipes `publish-docker.yml` + the multi-platform workflow, then `gh release create`, then a PR that bumps `CMakeLists.txt` `project(VERSION)` and squash-merges it. Never rewrite the just-tagged version.
 - Docker images: add a row to `publish-docker.yml` `jobs.publish.strategy.matrix.include`. No hardcoded image names — `ghcr.io/${{ github.repository }}/<name>`.
 - New matrix entries must use existing presets from `CMakePresets.json`.
 - Do NOT add platform-specific hack scripts in CI — encode logic in presets or Docker.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,11 +73,14 @@ pre-commit install
 
 ## Releasing
 
-Click [▶ run release](https://github.com/e-gleba/cmake_template/actions/workflows/release.yml). Input `vX.Y.Z`. That workflow:
+Click [▶ run release](https://github.com/e-gleba/cmake_template/actions/workflows/release.yml). Inputs: `version` (`vX.Y.Z`) and `next_version` (`X.Y.Z`, no `v`). That workflow:
 
 1. Optionally publishes toolchain images (`publish-docker.yml`, one job per matrix row).
 2. Reuses `cmake_multi_platform.yml` — no duplicated build jobs.
 3. Tags the SHA and attaches CPack / APK artifacts.
+4. Opens a PR that bumps `project(VERSION)` in `CMakeLists.txt` to `next_version`, then squash-merges it. The just-shipped tag keeps the old version so packages match their tag.
+
+Requires **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"**. If merge is blocked (reviews / checks), the PR stays open.
 
 Workflow YAML starts with `# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json` so editors validate locally. Add a Docker image by adding a matrix row in `publish-docker.yml`. Dependabot watches `.github/workflows` and `docker/`.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -95,8 +95,9 @@ Add an image: one row in `jobs.publish.strategy.matrix.include`.
 1. Calls `publish-docker.yml` (optional, parallel, one job per image).
 2. Calls `cmake_multi_platform.yml` (same matrix as CI — no duplicated jobs).
 3. Tags `vX.Y.Z` and attaches CPack / APK artifacts via `gh release create`.
+4. Opens + squash-merges a PR that bumps `project(VERSION)` in `CMakeLists.txt` to the `next_version` you typed. The just-shipped tag stays at the old version.
 
-Click **▶ run release** on the README, type `v1.2.3`.
+Click **▶ run release** on the README, type `v1.2.3` and next CMake version `1.2.4`.
 
 ## Troubleshooting
 

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ cmake --workflow --preset=android-arm64-full
 cmake --workflow --preset=llvm-mingw-aarch64-full
 ```
 
-**Release:** click [▶ run release](https://github.com/e-gleba/cmake_template/actions/workflows/release.yml), type `v1.2.3`. Builds every platform, optionally pushes GHCR images, tags, attaches CPack/APK artifacts.
+**Release:** click [▶ run release](https://github.com/e-gleba/cmake_template/actions/workflows/release.yml), type `v1.2.3` and next CMake version (`1.2.4`). Builds every platform, optionally pushes GHCR images, tags, attaches CPack/APK artifacts, then opens+merges a PR bumping `project(VERSION)` on main.
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Summary
Port the wemod_enhancer post-release CMake version bump into `release.yml`, but open+merge a PR instead of pushing main directly.

## Related Issue
No issue — release plumbing, same idea as [wemod_enhancer `publish_release.yml`](https://github.com/e-gleba/wemod_enhancer/blob/main/.github/workflows/publish_release.yml) `bump_cmake_version` job.

## Changes
- `.github/workflows/release.yml` — new required `next_version` input (`1.2.4`, no `v`). After `publish` succeeds, `bump_cmake_version` validates semver `>` current `project(VERSION)`, `sed`s `CMakeLists.txt`, opens a PR, squash-merges it. Tag/artifacts stay on the old version.
- `readme.md`, `docs/docker.md`, `docs/contributing.md`, `CLAUDE.md` — document the extra input and the PR path.

`android-project/app/build.gradle` `versionName` left alone — only `CMakeLists.txt` `project(VERSION)` is the source of truth, same as wemod.

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [x] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed

Workflow-only change. Lint job on this PR is the check. First real exercise is the next ▶ run release.

## Notes for Reviewer
- wemod pushes the bump commit straight to `main`. Here the bump goes through a PR because you asked for create+merge.
- Needs **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"**. If merge is blocked (reviews / required checks), the PR stays open and the job warns instead of failing.
- Inputs bound via `env:` so they never expand into shell source (same zizmor note as wemod).
- `next_version` is required so a release cannot ship without deciding the next `project(VERSION)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release workflows now accept both the shipped version and the next project version.
  - After publishing, the workflow automatically opens a pull request to update the project version and attempts to squash-merge it.
  - Published packages retain the shipped release version.

- **Documentation**
  - Updated release guidance across project documentation, including required inputs and pull request behavior.
  - Added notes about permissions and conditions that may leave the version-update pull request open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->