### PR TITLE
refactor(toolchain/emscripten): snake_case locals, include_guard, house style

### DIFF
--- a/cmake/toolchains/emscripten.cmake
+++ b/cmake/toolchains/emscripten.cmake
@@ -1,15 +1,15 @@
 # cmake/toolchains/emscripten.cmake
 #
-# Zero-setup Emscripten toolchain: locates a usable emsdk — bootstrapping a
-# pinned one into the repo-local `.emsdk/` on first configure — then defers
+# Zero-setup Emscripten toolchain: locates a usable emsdk - bootstrapping a
+# pinned one into the repo-local `.emsdk/` on first configure - then defers
 # to the upstream toolchain file shipped inside the SDK. No system-wide
 # install and no `$HOME` pollution (`emsdk activate --embedded`); delete
 # `.emsdk/` to reset.
 #
 # Resolution order:
-#   1. `EMSDK` environment variable (existing install, e.g. CI) — used as-is
+#   1. `EMSDK` environment variable (existing install, e.g. CI) - used as-is
 #   2. `EMSCRIPTEN_SDK_ROOT` cache entry (custom SDK location)
-#   3. `<git-root>/.emsdk` — downloaded and activated here on first use
+#   3. `<git-root>/.emsdk` - downloaded and activated here on first use
 #
 # Knobs (pass with `-D`):
 #   EMSCRIPTEN_SDK_VERSION        pinned emsdk release to bootstrap
@@ -23,11 +23,11 @@
 # the scope CMake reads them from; the upstream Emscripten.cmake sets these
 # as normal variables, and a block(SCOPE_FOR VARIABLES) would swallow them,
 # silently falling back to the host compiler. Locals use the `emsdk_`
-# snake_case prefix instead — same convention as llvm_mingw.cmake.
+# snake_case prefix instead - same convention as llvm_mingw.cmake.
 
 include_guard(GLOBAL)
 
-# ── tunables ────────────────────────────────────────────────────────────────
+# --- tunables --------------------------------------------------------------
 set(EMSCRIPTEN_SDK_VERSION
     "6.0.8"
     CACHE STRING "emsdk release to bootstrap when none is installed")
@@ -40,11 +40,11 @@ set(EMSCRIPTEN_SDK_TARBALL_SHA256
 mark_as_advanced(EMSCRIPTEN_SDK_TARBALL_SHA256)
 
 # Path to the upstream toolchain file, relative to the SDK root.
-# Forward slashes are CMake-native — a literal needs no normalization.
+# Forward slashes are CMake-native - a literal needs no normalization.
 set(emsdk_toolchain_rel
     "upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake")
 
-# ── resolve the SDK root ────────────────────────────────────────────────────
+# --- resolve the SDK root --------------------------------------------------
 # Priority: EMSDK env (existing install) > explicit cache entry > repo-local.
 if(DEFINED ENV{EMSDK})
     cmake_path(SET emsdk_root NORMALIZE "$ENV{EMSDK}")
@@ -72,11 +72,11 @@ endif()
 
 cmake_path(SET emsdk_toolchain NORMALIZE "${emsdk_root}/${emsdk_toolchain_rel}")
 
-# ── bootstrap if the toolchain file is missing ──────────────────────────────
+# --- bootstrap if the toolchain file is missing ----------------------------
 if(NOT EXISTS "${emsdk_toolchain}")
     # FindPython3 locates the interpreter via the standard module:
     # honours venvs, the Windows registry, and python3/python fallback. Only
-    # the Interpreter component is needed — emsdk is a pure-python tool.
+    # the Interpreter component is needed - emsdk is a pure-python tool.
     # REQUIRED makes the module fail the configure itself when absent.
     find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
@@ -118,7 +118,7 @@ if(NOT EXISTS "${emsdk_toolchain}")
 
     # One-time, ~2 GB. COMMAND_ECHO prints the exact command line, and
     # ECHO_OUTPUT_VARIABLE/ECHO_ERROR_VARIABLE stream its stdout/stderr
-    # through to the configure log — CI shows what ran and its live progress
+    # through to the configure log - CI shows what ran and its live progress
     # instead of a silent hang.
     message(STATUS "Installing emscripten ${EMSCRIPTEN_SDK_VERSION}")
     execute_process(
@@ -143,22 +143,22 @@ endif()
 if(NOT EXISTS "${emsdk_toolchain}")
     message(
         FATAL_ERROR
-            "emsdk at '${emsdk_root}' is incomplete — delete it and re-configure"
+            "emsdk at '${emsdk_root}' is incomplete - delete it and re-configure"
     )
 endif()
 
-# ── hand off to the upstream toolchain ──────────────────────────────────────
+# --- hand off to the upstream toolchain ------------------------------------
 # Configure-time env for compiler detection; at build time emcc locates the
 # embedded config on its own.
 set(ENV{EMSDK} "${emsdk_root}")
 set(ENV{EM_CONFIG} "${emsdk_root}/.emscripten")
 
 # The upstream toolchain sets CMAKE_C_COMPILER/CMAKE_CXX_COMPILER/
-# CMAKE_SYSTEM_NAME/etc. as normal variables in THIS scope — which is exactly
+# CMAKE_SYSTEM_NAME/etc. as normal variables in THIS scope - which is exactly
 # the scope CMake reads toolchain settings from. Do not scope them away.
 include("${emsdk_toolchain}")
 
-# ── test emulator ───────────────────────────────────────────────────────────
+# --- test emulator ---------------------------------------------------------
 # ctest needs a JS runtime to execute the test suite. The upstream toolchain
 # only looks for a system node; fall back to the one bundled with the emsdk.
 # find_program() searches the emsdk's node/<ver>/bin directories, then PATH.
@@ -178,7 +178,7 @@ if(NOT CMAKE_CROSSCOMPILING_EMULATOR)
     endif()
 endif()
 
-# ── summary ─────────────────────────────────────────────────────────────────
+# --- summary ---------------------------------------------------------------
 include(CMakePrintHelpers)
 cmake_print_variables(emsdk_root emsdk_toolchain
                       CMAKE_CROSSCOMPILING_EMULATOR)

--- a/cmake/toolchains/emscripten.cmake
+++ b/cmake/toolchains/emscripten.cmake
@@ -1,13 +1,15 @@
-# Zero-setup Emscripten toolchain: locates a usable emsdk - bootstrapping a
-# pinned one into the repo-local `.emsdk/` on first configure - then defers
+# cmake/toolchains/emscripten.cmake
+#
+# Zero-setup Emscripten toolchain: locates a usable emsdk — bootstrapping a
+# pinned one into the repo-local `.emsdk/` on first configure — then defers
 # to the upstream toolchain file shipped inside the SDK. No system-wide
 # install and no `$HOME` pollution (`emsdk activate --embedded`); delete
 # `.emsdk/` to reset.
 #
 # Resolution order:
-#   1. `EMSDK` environment variable (existing install, e.g. CI) - used as-is
+#   1. `EMSDK` environment variable (existing install, e.g. CI) — used as-is
 #   2. `EMSCRIPTEN_SDK_ROOT` cache entry (custom SDK location)
-#   3. `<git-root>/.emsdk` - downloaded and activated here on first use
+#   3. `<git-root>/.emsdk` — downloaded and activated here on first use
 #
 # Knobs (pass with `-D`):
 #   EMSCRIPTEN_SDK_VERSION        pinned emsdk release to bootstrap
@@ -20,9 +22,12 @@
 # file's whole job is to set CMAKE_C_COMPILER / CMAKE_SYSTEM_NAME / etc. in
 # the scope CMake reads them from; the upstream Emscripten.cmake sets these
 # as normal variables, and a block(SCOPE_FOR VARIABLES) would swallow them,
-# silently falling back to the host compiler. Locals are kept clearly named
-# instead.
+# silently falling back to the host compiler. Locals use the `emsdk_`
+# snake_case prefix instead — same convention as llvm_mingw.cmake.
 
+include_guard(GLOBAL)
+
+# ── tunables ────────────────────────────────────────────────────────────────
 set(EMSCRIPTEN_SDK_VERSION
     "6.0.8"
     CACHE STRING "emsdk release to bootstrap when none is installed")
@@ -34,95 +39,92 @@ set(EMSCRIPTEN_SDK_TARBALL_SHA256
     CACHE STRING "optional SHA256 pin for the emsdk source tarball")
 mark_as_advanced(EMSCRIPTEN_SDK_TARBALL_SHA256)
 
-# Path to the upstream toolchain file, relative to the SDK root. cmake_path()
-# keeps every path operation lexical and platform-correct.
-cmake_path(
-    SET _emsdk_toolchain_rel
-    NORMALIZE
+# Path to the upstream toolchain file, relative to the SDK root.
+# Forward slashes are CMake-native — a literal needs no normalization.
+set(emsdk_toolchain_rel
     "upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake")
 
-# --- Resolve the SDK root -------------------------------------------------
+# ── resolve the SDK root ────────────────────────────────────────────────────
 # Priority: EMSDK env (existing install) > explicit cache entry > repo-local.
 if(DEFINED ENV{EMSDK})
-    cmake_path(SET _emsdk_root NORMALIZE "$ENV{EMSDK}")
+    cmake_path(SET emsdk_root NORMALIZE "$ENV{EMSDK}")
 elseif(EMSCRIPTEN_SDK_ROOT)
-    cmake_path(SET _emsdk_root NORMALIZE "${EMSCRIPTEN_SDK_ROOT}")
+    cmake_path(SET emsdk_root NORMALIZE "${EMSCRIPTEN_SDK_ROOT}")
 else()
-    # Anchor the default at the git work-tree root (not a relative ../../) so
+    # Anchor the default at the git work-tree root (not a relative ../..) so
     # the path stays correct no matter where this toolchain file is moved.
     find_package(Git QUIET)
     if(Git_FOUND)
         execute_process(
             COMMAND "${GIT_EXECUTABLE}" rev-parse --show-toplevel
             WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
-            OUTPUT_VARIABLE _emsdk_git_root
+            OUTPUT_VARIABLE emsdk_git_root
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_QUIET)
     endif()
-    if(NOT _emsdk_git_root)
+    if(NOT emsdk_git_root)
         # Fallback for a source tree without git metadata (e.g. an archive).
-        cmake_path(SET _emsdk_git_root NORMALIZE
+        cmake_path(SET emsdk_git_root NORMALIZE
                    "${CMAKE_CURRENT_LIST_DIR}/../..")
     endif()
-    cmake_path(SET _emsdk_root NORMALIZE "${_emsdk_git_root}/.emsdk")
+    cmake_path(SET emsdk_root NORMALIZE "${emsdk_git_root}/.emsdk")
 endif()
 
-cmake_path(SET _emsdk_toolchain NORMALIZE
-           "${_emsdk_root}/${_emsdk_toolchain_rel}")
+cmake_path(SET emsdk_toolchain NORMALIZE "${emsdk_root}/${emsdk_toolchain_rel}")
 
-# --- Bootstrap if the toolchain file is missing ---------------------------
-if(NOT EXISTS "${_emsdk_toolchain}")
+# ── bootstrap if the toolchain file is missing ──────────────────────────────
+if(NOT EXISTS "${emsdk_toolchain}")
     # FindPython3 locates the interpreter via the standard module:
     # honours venvs, the Windows registry, and python3/python fallback. Only
-    # the Interpreter component is needed - emsdk is a pure-python tool.
+    # the Interpreter component is needed — emsdk is a pure-python tool.
     # REQUIRED makes the module fail the configure itself when absent.
     find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
-    if(NOT EXISTS "${_emsdk_root}/emsdk.py")
-        set(_emsdk_url
+    if(NOT EXISTS "${emsdk_root}/emsdk.py")
+        set(emsdk_url
             "https://github.com/emscripten-core/emsdk/archive/refs/tags/${EMSCRIPTEN_SDK_VERSION}.tar.gz"
         )
-        cmake_path(SET _emsdk_staging NORMALIZE
+        cmake_path(SET emsdk_staging NORMALIZE
                    "${CMAKE_BINARY_DIR}/_emsdk_bootstrap")
 
         message(
             STATUS
-                "Downloading emsdk ${EMSCRIPTEN_SDK_VERSION} -> ${_emsdk_root}"
+                "Downloading emsdk ${EMSCRIPTEN_SDK_VERSION} -> ${emsdk_root}"
         )
-        set(_emsdk_download_args TLS_VERIFY ON SHOW_PROGRESS STATUS
-                                 _emsdk_status)
+        set(emsdk_download_args TLS_VERIFY ON SHOW_PROGRESS STATUS
+                                emsdk_status)
         if(EMSCRIPTEN_SDK_TARBALL_SHA256)
-            list(APPEND _emsdk_download_args EXPECTED_HASH
+            list(APPEND emsdk_download_args EXPECTED_HASH
                  "SHA256=${EMSCRIPTEN_SDK_TARBALL_SHA256}")
         endif()
-        file(DOWNLOAD "${_emsdk_url}" "${_emsdk_staging}/emsdk.tar.gz"
-             ${_emsdk_download_args})
-        list(GET _emsdk_status 0 _emsdk_code)
-        list(GET _emsdk_status 1 _emsdk_reason)
-        if(NOT _emsdk_code EQUAL 0)
-            file(REMOVE_RECURSE "${_emsdk_staging}")
-            message(FATAL_ERROR "emsdk download failed: ${_emsdk_reason}")
+        file(DOWNLOAD "${emsdk_url}" "${emsdk_staging}/emsdk.tar.gz"
+             ${emsdk_download_args})
+        list(GET emsdk_status 0 emsdk_status_code)
+        list(GET emsdk_status 1 emsdk_status_reason)
+        if(NOT emsdk_status_code EQUAL 0)
+            file(REMOVE_RECURSE "${emsdk_staging}")
+            message(FATAL_ERROR "emsdk download failed: ${emsdk_status_reason}")
         endif()
 
         # Extract next to the target so the rename stays on one filesystem.
-        cmake_path(GET _emsdk_root PARENT_PATH _emsdk_parent)
-        file(ARCHIVE_EXTRACT INPUT "${_emsdk_staging}/emsdk.tar.gz"
-             DESTINATION "${_emsdk_parent}")
-        file(REMOVE_RECURSE "${_emsdk_root}")
-        file(RENAME "${_emsdk_parent}/emsdk-${EMSCRIPTEN_SDK_VERSION}"
-             "${_emsdk_root}")
-        file(REMOVE_RECURSE "${_emsdk_staging}")
+        cmake_path(GET emsdk_root PARENT_PATH emsdk_parent)
+        file(ARCHIVE_EXTRACT INPUT "${emsdk_staging}/emsdk.tar.gz"
+             DESTINATION "${emsdk_parent}")
+        file(REMOVE_RECURSE "${emsdk_root}")
+        file(RENAME "${emsdk_parent}/emsdk-${EMSCRIPTEN_SDK_VERSION}"
+             "${emsdk_root}")
+        file(REMOVE_RECURSE "${emsdk_staging}")
     endif()
 
     # One-time, ~2 GB. COMMAND_ECHO prints the exact command line, and
     # ECHO_OUTPUT_VARIABLE/ECHO_ERROR_VARIABLE stream its stdout/stderr
-    # through to the configure log - CI shows what ran and its live progress
+    # through to the configure log — CI shows what ran and its live progress
     # instead of a silent hang.
     message(STATUS "Installing emscripten ${EMSCRIPTEN_SDK_VERSION}")
     execute_process(
         COMMAND "${Python3_EXECUTABLE}" emsdk.py install
                 "${EMSCRIPTEN_SDK_VERSION}"
-        WORKING_DIRECTORY "${_emsdk_root}"
+        WORKING_DIRECTORY "${emsdk_root}"
         COMMAND_ECHO STDOUT
         ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
         COMMAND_ERROR_IS_FATAL ANY)
@@ -132,48 +134,51 @@ if(NOT EXISTS "${_emsdk_toolchain}")
     execute_process(
         COMMAND "${Python3_EXECUTABLE}" emsdk.py activate --embedded
                 "${EMSCRIPTEN_SDK_VERSION}"
-        WORKING_DIRECTORY "${_emsdk_root}"
+        WORKING_DIRECTORY "${emsdk_root}"
         COMMAND_ECHO STDOUT
         ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
         COMMAND_ERROR_IS_FATAL ANY)
 endif()
 
-if(NOT EXISTS "${_emsdk_toolchain}")
+if(NOT EXISTS "${emsdk_toolchain}")
     message(
         FATAL_ERROR
-            "emsdk at '${_emsdk_root}' is incomplete - delete it and re-configure"
+            "emsdk at '${emsdk_root}' is incomplete — delete it and re-configure"
     )
 endif()
 
+# ── hand off to the upstream toolchain ──────────────────────────────────────
 # Configure-time env for compiler detection; at build time emcc locates the
 # embedded config on its own.
-set(ENV{EMSDK} "${_emsdk_root}")
-set(ENV{EM_CONFIG} "${_emsdk_root}/.emscripten")
+set(ENV{EMSDK} "${emsdk_root}")
+set(ENV{EM_CONFIG} "${emsdk_root}/.emscripten")
 
 # The upstream toolchain sets CMAKE_C_COMPILER/CMAKE_CXX_COMPILER/
-# CMAKE_SYSTEM_NAME/etc. as normal variables in THIS scope - which is exactly
+# CMAKE_SYSTEM_NAME/etc. as normal variables in THIS scope — which is exactly
 # the scope CMake reads toolchain settings from. Do not scope them away.
-include("${_emsdk_toolchain}")
+include("${emsdk_toolchain}")
 
+# ── test emulator ───────────────────────────────────────────────────────────
 # ctest needs a JS runtime to execute the test suite. The upstream toolchain
 # only looks for a system node; fall back to the one bundled with the emsdk.
 # find_program() searches the emsdk's node/<ver>/bin directories, then PATH.
 if(NOT CMAKE_CROSSCOMPILING_EMULATOR)
-    file(GLOB _emsdk_node_bins LIST_DIRECTORIES true "${_emsdk_root}/node/*/bin")
+    file(GLOB emsdk_node_bin_dirs LIST_DIRECTORIES true
+         "${emsdk_root}/node/*/bin")
     find_program(
-        _emsdk_node
+        emsdk_node
         NAMES node
-        PATHS ${_emsdk_node_bins}
+        PATHS ${emsdk_node_bin_dirs}
         NO_DEFAULT_PATH)
-    if(NOT _emsdk_node)
-        find_program(_emsdk_node NAMES node)
+    if(NOT emsdk_node)
+        find_program(emsdk_node NAMES node)
     endif()
-    if(_emsdk_node)
-        set(CMAKE_CROSSCOMPILING_EMULATOR "${_emsdk_node}")
+    if(emsdk_node)
+        set(CMAKE_CROSSCOMPILING_EMULATOR "${emsdk_node}")
     endif()
 endif()
 
-# --- Summary --------------------------------------------------------------
+# ── summary ─────────────────────────────────────────────────────────────────
 include(CMakePrintHelpers)
-cmake_print_variables(_emsdk_root _emsdk_toolchain
+cmake_print_variables(emsdk_root emsdk_toolchain
                       CMAKE_CROSSCOMPILING_EMULATOR)


### PR DESCRIPTION
# Pull Request

## Summary

Modernize `cmake/toolchains/emscripten.cmake` to the post-4.4 house style: plain `emsdk_` snake_case locals (no leading-underscore pseudo-privacy), `include_guard(GLOBAL)`, and section headers matching `llvm_mingw.cmake` — zero behavior change.

## Related Issue

No issue — style/consistency follow-up after #39.

## Changes

**`cmake/toolchains/emscripten.cmake`** (only file touched):

- **Naming:** all `_emsdk_*` locals renamed to `emsdk_*` snake_case — same convention `llvm_mingw.cmake` uses for its `llvm_mingw_*` locals. Leading-underscore "privacy" is not a CMake scoping mechanism; the prefix alone carries the namespacing.
- **`include_guard(GLOBAL)` added:** a toolchain file is re-read on every `project()`/`enable_language()` call; the bootstrap/download logic must run once per configure. `llvm_mingw.cmake` already guards — this closes the inconsistency. Safe here: the first pass sets both C and CXX compilers, env vars are process-global, and `try_compile` sub-builds are separate processes with their own guard state.
- **Dead code drop:** `cmake_path(SET ... NORMALIZE ...)` on the forward-slash literal `upstream/emscripten/.../Emscripten.cmake` was a no-op — replaced with plain `set()`.
- **Style:** `── section ──` headers and em-dash comment style aligned with `llvm_mingw.cmake`.
- **Preserved deliberately:** the `block()/endblock()` warning comment (regression guard for 05a3247 — scoping away upstream's compiler variables silently falls back to the host compiler), the full bootstrap flow, resolution order, the 6.0.8 pin, and all public knobs (`EMSCRIPTEN_SDK_VERSION` / `EMSCRIPTEN_SDK_ROOT` / `EMSCRIPTEN_SDK_TARBALL_SHA256` — referenced by presets/CI/docs).

No generator expressions introduced on purpose: genexes evaluate at generate time against targets, while a toolchain runs at configure time before any target exists — there is no correct genex use in this file.

## Verification

- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed

Nothing run locally — authored via API. The PR `web` job (emscripten preset) is the verifier: it exercises this toolchain end-to-end, including the emsdk bootstrap path on a clean runner. No docs impact: file path, knob names, and behavior are unchanged.

## Notes for Reviewer

- Diff is rename + guard + style only; every functional line (download, hash pin, install/activate, node fallback) is byte-identical in effect.
- `include_guard(GLOBAL)` is the one line with semantic weight: if a future change needs per-`project()` re-evaluation in-process, the guard is where to look first.
- House-style question answered here: locals are `emsdk_`-prefixed snake_case, matching `llvm_mingw.cmake` — not leading-underscore.