### PR TITLE
refactor(toolchain/llvm-mingw): ASCII comments, hash-pin knob, compact forms

### DIFF
--- a/cmake/toolchains/llvm_mingw.cmake
+++ b/cmake/toolchains/llvm_mingw.cmake
@@ -5,13 +5,14 @@
 #              -DCMAKE_SYSTEM_PROCESSOR=x86_64|i686|aarch64
 #
 # Tunables (all overridable via -D or cache):
-#   LLVM_MINGW_VERSION       — release tag  (default: 20260616)
-#   LLVM_MINGW_HOST_OS       — package OS suffix (default: ubuntu-22.04)
-#   LLVM_MINGW_AUTO_DOWNLOAD — fetch if absent   (default: ON)
+#   LLVM_MINGW_VERSION        release tag (default: 20260616)
+#   LLVM_MINGW_HOST_OS        package OS suffix (default: ubuntu-22.04)
+#   LLVM_MINGW_AUTO_DOWNLOAD  fetch if absent (default: ON)
+#   LLVM_MINGW_TARBALL_SHA256 optional integrity pin for the tarball
 
 include_guard(GLOBAL)
 
-# ── target system ─────────────────────────────────────────────────────────────
+# --- target system -----------------------------------------------------------
 # Must be set before project() sees the toolchain file.
 set(CMAKE_SYSTEM_NAME Windows)
 
@@ -19,7 +20,7 @@ if(NOT DEFINED CMAKE_SYSTEM_PROCESSOR)
     set(CMAKE_SYSTEM_PROCESSOR x86_64)
 endif()
 
-# ── tunables ──────────────────────────────────────────────────────────────────
+# --- tunables ----------------------------------------------------------------
 set(LLVM_MINGW_VERSION
     "20260616"
     CACHE STRING "llvm-mingw release tag")
@@ -27,19 +28,23 @@ set(LLVM_MINGW_HOST_OS
     "ubuntu-22.04"
     CACHE STRING "llvm-mingw host OS package suffix")
 option(LLVM_MINGW_AUTO_DOWNLOAD "Download llvm-mingw if absent" ON)
+set(LLVM_MINGW_TARBALL_SHA256
+    ""
+    CACHE STRING "optional SHA256 pin for the llvm-mingw tarball")
+mark_as_advanced(LLVM_MINGW_TARBALL_SHA256)
 
-# ── host arch ─────────────────────────────────────────────────────────────────
-# Separate from CMAKE_HOST_SYSTEM_PROCESSOR: that variable is not always set
-# on older CMake; the MATCHES form is robust across Linux/macOS CI runners.
+# --- host arch ---------------------------------------------------------------
+# Normalize the arm64 spelling variants across host OSes (macOS arm64,
+# Linux aarch64, Windows ARM64); MATCHES has no case-insensitive flag.
 if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
     set(llvm_mingw_host_arch aarch64)
 else()
     set(llvm_mingw_host_arch x86_64)
 endif()
 
-# ── target triple ─────────────────────────────────────────────────────────────
+# --- target triple -----------------------------------------------------------
 # llvm-mingw ships one sysroot directory per Windows ABI target.
-# The triple must match exactly or the linker will pick up wrong CRT objects.
+# The triple must match exactly or the linker picks up wrong CRT objects.
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
     set(llvm_mingw_triple aarch64-w64-mingw32)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
@@ -53,20 +58,12 @@ else()
             "Supported: x86_64, i686, aarch64")
 endif()
 
-# ── paths ─────────────────────────────────────────────────────────────────────
+# --- paths -------------------------------------------------------------------
 # Anchor to the project root (two levels up from cmake/toolchains/).
 # CMAKE_SOURCE_DIR is NOT used here: it breaks in try_compile() sub-projects
 # and FetchContent calls, where CMAKE_SOURCE_DIR points at the sub-project.
-cmake_path(
-    GET
-    CMAKE_CURRENT_LIST_DIR
-    PARENT_PATH
-    llvm_mingw_cmake_dir)
-cmake_path(
-    GET
-    llvm_mingw_cmake_dir
-    PARENT_PATH
-    llvm_mingw_project_root)
+cmake_path(GET CMAKE_CURRENT_LIST_DIR PARENT_PATH llvm_mingw_cmake_dir)
+cmake_path(GET llvm_mingw_cmake_dir PARENT_PATH llvm_mingw_project_root)
 
 set(llvm_mingw_install_dir "${llvm_mingw_project_root}/llvm_mingw")
 set(llvm_mingw_pkg
@@ -78,7 +75,7 @@ set(llvm_mingw_url
 set(llvm_mingw_archive "${llvm_mingw_project_root}/${llvm_mingw_pkg}.tar.xz")
 set(llvm_mingw_sysroot "${llvm_mingw_install_dir}/${llvm_mingw_triple}")
 
-# ── download / extract ────────────────────────────────────────────────────────
+# --- download / extract ------------------------------------------------------
 # Probe the target-specific clang binary so a partial install (e.g. x86_64
 # present but i686 missing) is detected correctly per-triple.
 if(NOT EXISTS "${llvm_mingw_install_dir}/bin/${llvm_mingw_triple}-clang")
@@ -91,38 +88,26 @@ if(NOT EXISTS "${llvm_mingw_install_dir}/bin/${llvm_mingw_triple}-clang")
     endif()
 
     message(STATUS "llvm-mingw: fetching '${llvm_mingw_pkg}'")
-    file(
-        DOWNLOAD "${llvm_mingw_url}" "${llvm_mingw_archive}"
-        SHOW_PROGRESS
-        STATUS llvm_mingw_dl_status
-        TLS_VERIFY ON)
+    set(llvm_mingw_download_args TLS_VERIFY ON SHOW_PROGRESS STATUS
+                                 llvm_mingw_dl_status)
+    if(LLVM_MINGW_TARBALL_SHA256)
+        list(APPEND llvm_mingw_download_args EXPECTED_HASH
+             "SHA256=${LLVM_MINGW_TARBALL_SHA256}")
+    endif()
+    file(DOWNLOAD "${llvm_mingw_url}" "${llvm_mingw_archive}"
+         ${llvm_mingw_download_args})
 
-    list(
-        GET
-        llvm_mingw_dl_status
-        0
-        llvm_mingw_dl_code)
-    if(NOT
-       llvm_mingw_dl_code
-       EQUAL
-       0)
-        list(
-            GET
-            llvm_mingw_dl_status
-            1
-            llvm_mingw_dl_msg)
+    list(GET llvm_mingw_dl_status 0 llvm_mingw_dl_code)
+    if(NOT llvm_mingw_dl_code EQUAL 0)
+        list(GET llvm_mingw_dl_status 1 llvm_mingw_dl_msg)
         file(REMOVE "${llvm_mingw_archive}")
         message(
             FATAL_ERROR "llvm-mingw: download failed => ${llvm_mingw_dl_msg}")
     endif()
 
     message(STATUS "llvm-mingw: extracting '${llvm_mingw_pkg}.tar.xz'")
-    file(
-        ARCHIVE_EXTRACT
-        INPUT
-        "${llvm_mingw_archive}"
-        DESTINATION
-        "${llvm_mingw_project_root}")
+    file(ARCHIVE_EXTRACT INPUT "${llvm_mingw_archive}" DESTINATION
+         "${llvm_mingw_project_root}")
     file(REMOVE_RECURSE "${llvm_mingw_install_dir}")
     file(RENAME "${llvm_mingw_project_root}/${llvm_mingw_pkg}"
          "${llvm_mingw_install_dir}")
@@ -130,7 +115,7 @@ if(NOT EXISTS "${llvm_mingw_install_dir}/bin/${llvm_mingw_triple}-clang")
     message(STATUS "llvm-mingw: installed => '${llvm_mingw_install_dir}'")
 endif()
 
-# ── compilers & tools ─────────────────────────────────────────────────────────
+# --- compilers and tools -----------------------------------------------------
 # CACHE FILEPATH "" FORCE is required: CMake's compiler detection writes these
 # to CMakeCache.txt on first configure; FORCE ensures the toolchain always wins
 # over a stale cache entry left by a previous preset run.
@@ -153,7 +138,7 @@ set(CMAKE_LINKER
     "${llvm_mingw_install_dir}/bin/ld.lld"
     CACHE FILEPATH "" FORCE)
 
-# ── sysroot ───────────────────────────────────────────────────────────────────
+# --- sysroot -----------------------------------------------------------------
 # CMAKE_SYSROOT must NOT go into the cache. If cached, it survives preset
 # switches (e.g. x86_64 -> i686) and poisons subsequent configures even with
 # FORCE, because the cache is read before the toolchain file re-runs.
@@ -169,7 +154,7 @@ set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld --sysroot=${llvm_mingw_sysroot}")
 set(CMAKE_SHARED_LINKER_FLAGS_INIT
     "-fuse-ld=lld --sysroot=${llvm_mingw_sysroot}")
 
-# ── find_* scoping ────────────────────────────────────────────────────────────
+# --- find_* scoping ----------------------------------------------------------
 # Restrict all find_library/find_package/find_path calls to the target sysroot.
 # PROGRAM stays at NEVER so host tools (ninja, python, etc.) remain reachable.
 set(CMAKE_FIND_ROOT_PATH "${llvm_mingw_sysroot}")
@@ -178,7 +163,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
-# ── clang-tidy ────────────────────────────────────────────────────────────────
+# --- clang-tidy --------------------------------------------------------------
 # llvm-mingw releases do not ship clang-tidy. The host's clang-tidy is
 # version-mismatched against the bundled libc++ headers and produces false
 # errors (e.g. __countr_zero not found in <algorithm>). Disable unconditionally


### PR DESCRIPTION
# Pull Request

## Summary

Bring `cmake/toolchains/llvm_mingw.cmake` to the post-4.4 house style established in #40: ASCII-only comments, an optional tarball hash-pin knob for parity with `emscripten.cmake`, and compacted single-line forms — pin stays at 20260616.

## Related Issue

No issue — style/consistency follow-up after #39 and #40.

## Changes

**`cmake/toolchains/llvm_mingw.cmake`** (only file touched):

- **ASCII-only comments:** box-drawing `── section ──` headers replaced with `# --- section ---` rules, em-dashes with `-`. Matches the merged `emscripten.cmake` style.
- **`LLVM_MINGW_TARBALL_SHA256` added (only functional delta):** optional `EXPECTED_HASH` pin for the release tarball — the same knob `emscripten.cmake` exposes via `EMSCRIPTEN_SDK_TARBALL_SHA256`. Empty by default = zero behavior change; marked advanced. Download call switches to the args-list pattern to carry it.
- **Stale comment fixed:** the host-arch block claimed `CMAKE_HOST_SYSTEM_PROCESSOR` "is not always set on older CMake" — under the 4.4 floor it is always set; the `MATCHES` list exists to normalize the arm64/aarch64/ARM64 spelling variants across host OSes. Comment now says that.
- **Compaction:** `cmake_path(GET ...)`, `list(GET ...)`, `if(NOT ... EQUAL 0)`, and `file(ARCHIVE_EXTRACT ...)` collapse from exploded one-arg-per-line forms to the single-line style `emscripten.cmake` uses. Same semantics, less vertical noise.

**Pin NOT bumped, deliberately:** 20260721 / 20260728 / 20260812 are LLVM 23.1.0 RC1/RC2/RC3 prereleases; 20260616 (LLVM 22.1.8) remains the newest stable tag. A pinned toolchain tracks stable, not RCs.

No generator expressions, same reasoning as #40: a toolchain runs at configure time before any target exists — there is no correct genex use in this file.

## Verification

- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed

Nothing run locally — authored via API. The PR `cross-windows` jobs (llvm-mingw x86_64 / i686 / aarch64 presets) are the verifier: they exercise the download, extract, compiler, and sysroot paths on clean runners. No docs impact: file path, existing knob names, and defaults are unchanged.

## Notes for Reviewer

- Diff is style + compaction except the `LLVM_MINGW_TARBALL_SHA256` block — that is the one new code path, and it is inert unless set.
- Considered and skipped: `CMAKE_LINKER_TYPE` (3.29+) instead of `-fuse-ld=lld` in `*_FLAGS_INIT`. The explicit flag form is driver-agnostic and already correct; switching mechanisms would need CI validation across all three triples for zero user-visible gain. Revisit if linker selection ever becomes configurable.
- When LLVM 23.1.0 goes stable, the bump is a one-line `LLVM_MINGW_VERSION` change; Renovate already watches this file.