### PR TITLE
fix: Android doctest JUnit parsing, project()-driven CPack metadata, SDL3 self-warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 4.4)
 project(
     cxx_project
     VERSION 1.0.0
-    DESCRIPTION "My awesome C/C++ project!"
-    HOMEPAGE_URL "https://github.com/e-gleba/cxx-skeleton"
+    DESCRIPTION "Production-ready cross-platform C++ project template"
+    HOMEPAGE_URL "https://github.com/e-gleba/cmake_template"
     LANGUAGES C CXX)
 
 # No C++20 modules in use — do not pay for the module dependency scan.

--- a/android-project/app/src/androidTest/java/com/egleba/app/DoctestRunner.java
+++ b/android-project/app/src/androidTest/java/com/egleba/app/DoctestRunner.java
@@ -33,14 +33,11 @@ import java.util.Objects;
 public final class DoctestRunner extends ParentRunner<DoctestRunner.NativeTestCase> {
 
     /// A discovered native case: the JUnit-facing description plus the exact
-    /// doctest name needed to run it.
-    static final class NativeTestCase {
-        final Description description;
-        final String nativeName;
-
-        NativeTestCase(final Description description, final String nativeName) {
-            this.description = description;
-            this.nativeName = nativeName;
+    /// doctest name needed to run it. Immutable by construction (record).
+    record NativeTestCase(Description description, String nativeName) {
+        NativeTestCase {
+            Objects.requireNonNull(description, "description");
+            Objects.requireNonNull(nativeName, "nativeName");
         }
     }
 
@@ -79,7 +76,7 @@ public final class DoctestRunner extends ParentRunner<DoctestRunner.NativeTestCa
 
     @Override
     protected Description describeChild(final NativeTestCase child) {
-        return child.description;
+        return child.description();
     }
 
     @Override
@@ -87,13 +84,13 @@ public final class DoctestRunner extends ParentRunner<DoctestRunner.NativeTestCa
         runLeaf(new Statement() {
             @Override
             public void evaluate() {
-                final String report = NativeDoctestTests.runTest(child.nativeName);
+                final String report = NativeDoctestTests.runTest(child.nativeName());
                 if (report != null) {
                     throw new AssertionError(
-                            "Native doctest case failed: " + child.nativeName + '\n' + report);
+                            "Native doctest case failed: " + child.nativeName() + '\n' + report);
                 }
             }
-        }, child.description, notifier);
+        }, child.description(), notifier);
     }
 
     /// Makes a doctest case name safe for the line-based instrumentation

--- a/android-project/app/src/androidTest/java/com/egleba/app/DoctestRunner.java
+++ b/android-project/app/src/androidTest/java/com/egleba/app/DoctestRunner.java
@@ -34,8 +34,12 @@ public final class DoctestRunner extends ParentRunner<DoctestRunner.NativeTestCa
 
     /// A discovered native case: the JUnit-facing description plus the exact
     /// doctest name needed to run it. Immutable by construction (record).
-    record NativeTestCase(Description description, String nativeName) {
-        NativeTestCase {
+    ///
+    /// Public on purpose: the record is the type parameter of ParentRunner
+    /// and appears in the protected overrides below, so a package-private
+    /// type would be exposed outside its defined visibility scope.
+    public record NativeTestCase(Description description, String nativeName) {
+        public NativeTestCase {
             Objects.requireNonNull(description, "description");
             Objects.requireNonNull(nativeName, "nativeName");
         }

--- a/android-project/app/src/androidTest/java/com/egleba/app/DoctestRunner.java
+++ b/android-project/app/src/androidTest/java/com/egleba/app/DoctestRunner.java
@@ -1,0 +1,118 @@
+package com.egleba.app;
+
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/// JUnit4 runner that bridges native doctest cases into Android's
+/// instrumentation pipeline, one JUnit test per doctest case.
+///
+/// Replaces the previous Parameterized-runner bridge, which did not parse
+/// correctly:
+///   1. Every case ran as `runNative[<name>]` — a single synthetic method
+///      name, so results could not be read or filtered per case.
+///   2. Raw doctest names went straight into the line-based
+///      INSTRUMENTATION_STATUS protocol, where a name containing a newline or
+///      a control character corrupts ddmlib's InstrumentationResultParser.
+///   3. The native side ran doctest with no-exitcode, which forces
+///      Context::run() to return 0 even for failing cases — every test was
+///      reported as passed.
+///
+/// Here each case gets a display name sanitized for the status protocol and
+/// for XML consumers, and a failing case surfaces its full doctest report as
+/// the AssertionError message (the `<failure>` element in the JUnit XML).
+public final class DoctestRunner extends ParentRunner<DoctestRunner.NativeTestCase> {
+
+    /// A discovered native case: the JUnit-facing description plus the exact
+    /// doctest name needed to run it.
+    static final class NativeTestCase {
+        final Description description;
+        final String nativeName;
+
+        NativeTestCase(final Description description, final String nativeName) {
+            this.description = description;
+            this.nativeName = nativeName;
+        }
+    }
+
+    private final List<NativeTestCase> children;
+
+    public DoctestRunner(final Class<?> testClass) throws InitializationError {
+        super(testClass);
+
+        final String[] names = Objects.requireNonNull(
+                NativeDoctestTests.getTestNames(),
+                "Native test names must not be null — check that libtests is loaded and exports a valid test suite.");
+        if (names.length == 0) {
+            throw new InitializationError("No native doctest cases discovered in libtests");
+        }
+
+        final List<NativeTestCase> cases = new ArrayList<>(names.length);
+        final Map<String, Integer> displayNameCounts = new HashMap<>();
+        for (final String name : names) {
+            String displayName = toDisplayName(name);
+            final int seen = displayNameCounts.merge(displayName, 1, Integer::sum);
+            if (seen > 1) {
+                // Two native names sanitized to the same display name — keep
+                // the JUnit descriptions unique so reports never merge them.
+                displayName = displayName + " [" + seen + "]";
+            }
+            cases.add(new NativeTestCase(
+                    Description.createTestDescription(testClass, displayName), name));
+        }
+        children = Collections.unmodifiableList(cases);
+    }
+
+    @Override
+    protected List<NativeTestCase> getChildren() {
+        return children;
+    }
+
+    @Override
+    protected Description describeChild(final NativeTestCase child) {
+        return child.description;
+    }
+
+    @Override
+    protected void runChild(final NativeTestCase child, final RunNotifier notifier) {
+        runLeaf(new Statement() {
+            @Override
+            public void evaluate() {
+                final String report = NativeDoctestTests.runTest(child.nativeName);
+                if (report != null) {
+                    throw new AssertionError(
+                            "Native doctest case failed: " + child.nativeName + '\n' + report);
+                }
+            }
+        }, child.description, notifier);
+    }
+
+    /// Makes a doctest case name safe for the line-based instrumentation
+    /// status protocol and for XML 1.0 test reports: newlines and carriage
+    /// returns would corrupt ddmlib's key=value parsing, and the remaining
+    /// control characters are not representable in XML.
+    private static String toDisplayName(final String nativeName) {
+        final StringBuilder sanitized = new StringBuilder(nativeName.length());
+        for (int i = 0; i < nativeName.length(); ++i) {
+            final char c = nativeName.charAt(i);
+            if (c == '\n' || c == '\r') {
+                sanitized.append(' ');
+            } else if (Character.isISOControl(c)) {
+                sanitized.append('?');
+            } else {
+                sanitized.append(c);
+            }
+        }
+        final String trimmed = sanitized.toString().trim();
+        return trimmed.isEmpty() ? "<unnamed>" : trimmed;
+    }
+}

--- a/android-project/app/src/androidTest/java/com/egleba/app/NativeDoctestTests.java
+++ b/android-project/app/src/androidTest/java/com/egleba/app/NativeDoctestTests.java
@@ -3,31 +3,25 @@ package com.egleba.app;
 import android.os.Build;
 import static org.junit.Assume.assumeTrue;
 
-import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertTrue;
 
 /// On-device native test runner for Android instrumentation tests.
 ///
-/// Executes native C/C++ unit tests bundled in the APK via the Android NDK testing framework.
-/// Each native test is discovered at runtime and run as a separate JUnit parameterized test.
+/// Bridges the doctest cases compiled into libtests.so into Android's JUnit
+/// instrumentation pipeline: [DoctestRunner] discovers every native case via
+/// JNI and reports it as an individual JUnit test, so Android Studio, Gradle
+/// and the JUnit XML results parse each native case under its own name with
+/// its own failure output.
 ///
 /// @note Follows Android’s official on-device native testing guidance:
 ///       https://developer.android.com/ndk/guides/test-native-libraries
 ///       https://developer.android.com/training/testing/unit-testing/instrumented-unit-tests
 ///
+/// @see DoctestRunner
 /// @see https://developer.android.com/ndk/guides/test-native-libraries
 /// @see https://developer.android.com/training/testing/unit-testing/instrumented-unit-tests
 /// @see gradle task :app:connectedDebugAndroidTest
-@RunWith(Parameterized.class)
+@RunWith(DoctestRunner.class)
 public final class NativeDoctestTests {
 
     static {
@@ -35,24 +29,14 @@ public final class NativeDoctestTests {
         System.loadLibrary("tests");
     }
 
-    private static native String[] getTestNames();
+    /// @return the names of all registered doctest cases.
+    static native String[] getTestNames();
 
-    private static native boolean runTest(String name);
-
-    @Parameterized.Parameter
-    public String testName;
-
-    @Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        final String[] names = Objects.requireNonNull(getTestNames(),
-                "Native test names must not be null — check that libtests is loaded and exports a valid test suite.");
-        return Arrays.stream(names)
-                .map(name -> new Object[]{name})
-                .collect(Collectors.toList());
-    }
-
-    @Test
-    public void runNative() {
-        assertTrue("Native test failed: " + testName, runTest(testName));
-    }
+    /// Runs a single doctest case by its exact registered name.
+    ///
+    /// @return null when the case passes; the captured doctest console report
+    ///         when it fails. The report becomes the JUnit failure message, so
+    ///         native assertion details survive into the test reports instead
+    ///         of being lost to logcat.
+    static native String runTest(String name);
 }

--- a/cmake/cpm/sdl3-config.cmake
+++ b/cmake/cpm/sdl3-config.cmake
@@ -117,26 +117,43 @@ cpmaddpackage(
     "SDL_DISABLE_INSTALL_DOCS ON")
 
 # -------------------------------------------------------------------
-# Treat SDL as a system library: silence the warnings it raises when
-# compiled with its own aggressive flag set (SDL_AddCommonCompilerFlags
-# adds -Wall -Wundef -Wfloat-conversion -Wdocumentation -Wshadow ...).
-# CPM's SYSTEM TRUE marks SDL's *interface* include dirs SYSTEM, which
-# keeps SDL headers from warning in *our* TUs — but it does not stop SDL
-# warning on its *own* sources. Marking the targets SYSTEM here drops
-# those self-warnings from our build output.
+# Silence warnings from SDL's own compilation. SDL arms its targets
+# with an aggressive flag set (SDL_AddCommonCompilerFlags: -Wall
+# -Wundef -Wfloat-conversion -Wdocumentation -Wshadow ...), and any
+# compiler newer than SDL's CI matrix finds something to say.
+#
+# SYSTEM include dirs are not the tool for this job: CPM's SYSTEM TRUE
+# (and the SYSTEM default on imported targets) only marks SDL's
+# *interface* includes as system for *consuming* translation units —
+# warnings raised while compiling SDL's own sources are unaffected.
+# Inhibit warnings on SDL's compile-bearing targets directly; SDL is a
+# vetted third-party dependency, so its self-warnings are not
+# actionable in this build.
+#
+# Guarded on SDL3_SOURCE_DIR: only a CPM-fetched SDL compiles anything.
+# A system-provided SDL3 (CPM_USE_LOCAL_PACKAGES) is imported and needs
+# nothing. Targets are enumerated from the fetched tree itself so SDL
+# adding/renaming targets in a future bump stays covered; INTERFACE and
+# UTILITY targets compile no sources and are skipped.
 # -------------------------------------------------------------------
-foreach(sdl3_target IN ITEMS SDL3-shared SDL3-static SDL_uclibc SDL3_Headers)
-    if(TARGET ${sdl3_target})
-        get_target_property(sdl3_inc ${sdl3_target} INTERFACE_INCLUDE_DIRECTORIES)
-        if(sdl3_inc)
-            set_target_properties(${sdl3_target}
-                                  PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                                             "${sdl3_inc}")
+if(SDL3_SOURCE_DIR)
+    get_property(sdl3_targets
+                 DIRECTORY "${SDL3_SOURCE_DIR}"
+                 PROPERTY BUILDSYSTEM_TARGETS)
+    foreach(sdl3_target IN LISTS sdl3_targets)
+        get_target_property(sdl3_target_type ${sdl3_target} TYPE)
+        if(sdl3_target_type MATCHES "INTERFACE_LIBRARY|UTILITY")
+            continue()
         endif()
-    endif()
-endforeach()
-unset(sdl3_target)
-unset(sdl3_inc)
+        target_compile_options(
+            ${sdl3_target}
+            PRIVATE "$<$<COMPILE_LANG_AND_ID:C,GNU,Clang,AppleClang>:-w>"
+                    "$<$<COMPILE_LANG_AND_ID:C,MSVC>:/w>")
+    endforeach()
+    unset(sdl3_target)
+    unset(sdl3_target_type)
+    unset(sdl3_targets)
+endif()
 
 # -------------------------------------------------------------------
 # Normalise to the standard imported target name expected by downstreams

--- a/cmake/description/description.txt
+++ b/cmake/description/description.txt
@@ -1,9 +1,0 @@
-A clean, modern C++ project template designed for robustness and cross-platform compatibility.
-This template streamlines setup for new projects, featuring secure environment variable handling,
-system information gathering, and minimal, UNIX-style logging.
-It leverages the latest C++23 standards, explicit error handling, and modular design
-to minimize boilerplate and maximize maintainability.
-
-Ideal for rapid prototyping, CI/CD pipelines, and production-ready applications.
-Includes cross-platform support for Windows and Unix-like systems,
-with clear separation of concerns and no unnecessary dependencies.

--- a/cmake/description/package_description.cmake
+++ b/cmake/description/package_description.cmake
@@ -2,6 +2,12 @@
 # Sets CPack metadata and platform-specific packaging variables.
 # Loaded from the root CMakeLists.txt via include(package_description).
 #
+# Everything derivable comes from the root project() call
+# (PROJECT_NAME, PROJECT_VERSION, PROJECT_DESCRIPTION,
+# PROJECT_HOMEPAGE_URL) — edit project() once and every package,
+# desktop entry, and generated file follows. Only the fields project()
+# has no slot for (vendor, contact, license) are kept here.
+#
 # CMAKE_CURRENT_LIST_DIR = directory containing THIS file
 #                          (cmake/description/)
 # PROJECT_SOURCE_DIR     = root of the calling project
@@ -11,9 +17,9 @@
 # Ref: Professional CMake §8.3 "Project-relative Variables"
 # ───────────────────────────────────────────────────────────────────
 
-# ─── Project metadata ─────────────────────────────────────────────
+# ─── Project metadata (no project() slot for these) ───────────────
 set(PROJECT_VENDOR "e-gleba")
-set(PROJECT_CONTACT "glebajk@gmail.com")
+set(PROJECT_CONTACT "i@egleba.ru")
 set(PROJECT_LICENSE "MIT") # SPDX identifier
 set(PROJECT_GROUP "System")
 
@@ -34,20 +40,25 @@ set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_LICENSE_FILE}")
 set(CPACK_RESOURCE_FILE_README "${PROJECT_README_FILE}")
 set(CPACK_VERBATIM_VARIABLES YES) # always set, prevents escaping bugs
 
-# Long description: use dedicated file if present, fall back
-# to the project readme.  block() isolates the temp variable.
-block(SCOPE_FOR VARIABLES) # no manual unset() needed
-set(pkg_desc_file "${CMAKE_CURRENT_LIST_DIR}/description.txt")
-if(EXISTS "${pkg_desc_file}")
-    set(CPACK_PACKAGE_DESCRIPTION_FILE
-        "${pkg_desc_file}"
-        PARENT_SCOPE)
-else()
-    set(CPACK_PACKAGE_DESCRIPTION_FILE
-        "${PROJECT_README_FILE}"
-        PARENT_SCOPE)
-endif()
-endblock()
+# ─── Long description ──────────────────────────────────────────────
+# Generated from the root project() metadata — no hand-maintained text
+# file to drift out of sync with the project. file(GENERATE) writes
+# into the build tree and only when the content changes, so the source
+# tree stays clean and re-configures stay cheap.
+set(CPACK_PACKAGE_DESCRIPTION_FILE
+    "${PROJECT_BINARY_DIR}/package_description.txt")
+file(
+    GENERATE
+    OUTPUT "${CPACK_PACKAGE_DESCRIPTION_FILE}"
+    CONTENT
+        "${PROJECT_DESCRIPTION}
+
+Version:  ${PROJECT_VERSION}
+Homepage: ${PROJECT_HOMEPAGE_URL}
+Vendor:   ${PROJECT_VENDOR}
+Contact:  ${PROJECT_CONTACT}
+License:  ${PROJECT_LICENSE}
+")
 
 # ─── CPack icon ────────────────────────────────────────────────────
 if(EXISTS "${PROJECT_ICON_FILE}")

--- a/cmake/description/package_description.cmake
+++ b/cmake/description/package_description.cmake
@@ -42,13 +42,16 @@ set(CPACK_VERBATIM_VARIABLES YES) # always set, prevents escaping bugs
 
 # ─── Long description ──────────────────────────────────────────────
 # Generated from the root project() metadata — no hand-maintained text
-# file to drift out of sync with the project. file(GENERATE) writes
-# into the build tree and only when the content changes, so the source
-# tree stays clean and re-configures stay cheap.
+# file to drift out of sync with the project. Must exist at configure
+# time: include(CPack) validates CPACK_PACKAGE_DESCRIPTION_FILE when it
+# is included, so a generate-time file(GENERATE) is too late and fails
+# with "CPack package description file ... could not be found".
+# file(CONFIGURE) writes immediately and, like configure_file(), only
+# touches the file when the content changes — re-configures stay cheap.
 set(CPACK_PACKAGE_DESCRIPTION_FILE
     "${PROJECT_BINARY_DIR}/package_description.txt")
 file(
-    GENERATE
+    CONFIGURE
     OUTPUT "${CPACK_PACKAGE_DESCRIPTION_FILE}"
     CONTENT
         "${PROJECT_DESCRIPTION}

--- a/tests/doctest_android_jni.cpp
+++ b/tests/doctest_android_jni.cpp
@@ -5,8 +5,10 @@
 #include <cstddef>
 #include <exception>
 #include <iostream>
+#include <optional>
 #include <ranges>
 #include <span>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -232,12 +234,36 @@ namespace {
 
 // ─── Test runner ──────────────────────────────────────────────────────────────
 
-    [[nodiscard]] bool run_single_doctest(const char *test_case_name) {
+    // Runs a single doctest case with its console report captured.
+    //
+    // no-exitcode must stay OFF: with it, Context::run() returns 0 even when
+    // cases fail (doctest context.cpp: `if (p->numTestCasesFailed &&
+    // !p->no_exitcode) return EXIT_FAILURE;`), so every JNI call would report
+    // success and failing cases would never reach the JUnit results.
+    //
+    // Returns the captured report on failure, nullopt on pass. The report is
+    // also mirrored to logcat through the process-wide redirect, so device
+    // logs keep the full output either way.
+    [[nodiscard]] std::optional<std::string>
+    run_single_doctest(const char *test_case_name) {
+        std::ostringstream report;
+
         doctest::Context context {};
         context.setOption("test-case", test_case_name);
         context.setOption("duration", true);
-        context.setOption("no-exitcode", true);
-        return context.run() == 0;
+        context.setCout(&report);
+
+        const int exit_code = context.run();
+
+        const std::string output = report.str();
+        if (!output.empty()) {
+            std::cout << output;
+        }
+
+        if (exit_code == 0) {
+            return std::nullopt;
+        }
+        return output;
     }
 
     template<std::ranges::sized_range Range>
@@ -289,12 +315,20 @@ Java_com_egleba_app_NativeDoctestTests_getTestNames(JNIEnv *env,
     });
 }
 
-JNIEXPORT jboolean JNICALL
+// Returns null when the case passes, or the captured doctest report when it
+// fails — the Java runner turns a non-null report into an AssertionError, so
+// the native assertion details land in the JUnit failure message and XML.
+JNIEXPORT jstring JNICALL
 Java_com_egleba_app_NativeDoctestTests_runTest(JNIEnv *env, jclass /*unused*/,
                                                jstring jname) {
-    return guard_jni(env, "runTest", [env, jname]() -> jboolean {
+    return guard_jni(env, "runTest", [env, jname]() -> jstring {
         const jni_utf_string test_name{env, jname};
-        return run_single_doctest(test_name.c_str()) ? JNI_TRUE : JNI_FALSE;
+        const std::optional<std::string> failure =
+                run_single_doctest(test_name.c_str());
+        if (!failure.has_value()) {
+            return nullptr;
+        }
+        return env->NewStringUTF(failure->c_str());
     });
 }
 // NOLINTEND(readability-identifier-naming)

--- a/tests/doctest_android_jni.cpp
+++ b/tests/doctest_android_jni.cpp
@@ -255,7 +255,8 @@ namespace {
 
         const int exit_code = context.run();
 
-        const std::string output = report.str();
+        // non-const on purpose: the return below must move, not copy
+        std::string output = report.str();
         if (!output.empty()) {
             std::cout << output;
         }


### PR DESCRIPTION
# Pull Request

## Summary
Upgrades the Android doctest integration so instrumented results parse correctly (per-case JUnit runner, real pass/fail propagation), makes CPack metadata derive entirely from the root `project()` call, and actually silences SDL3's self-compile warnings.

## Related Issue
Refs #23 — Phase 1 (doctest JNI runner for Android instrumentation).

## Changes

### Android doctest integration
- `tests/doctest_android_jni.cpp`
  - **Root-cause fix:** dropped `no-exitcode` from the per-case run. With it, `Context::run()` returns `0` even when cases fail (doctest `context.cpp`: `if (p->numTestCasesFailed && !p->no_exitcode) return EXIT_FAILURE;`), so every instrumentation test was reported as **passed** regardless of the real outcome.
  - `runTest` now captures the doctest console report via the official `Context::setCout(std::ostream*)` hook and returns it as a jstring (`null` = pass) instead of `jboolean`. Output is still mirrored to logcat through the existing redirect, so device logs keep everything.
  - Captured report string is non-const so the return moves instead of copies (clang-tidy `performance-no-automatic-move`).
- `android-project/app/src/androidTest/java/com/egleba/app/NativeDoctestTests.java` — slimmed to a `@RunWith(DoctestRunner.class)` shell holding the JNI declarations (JNI export names unchanged; `runTest` signature updated on both sides).
- `android-project/app/src/androidTest/java/com/egleba/app/DoctestRunner.java` (new) — JUnit4 `ParentRunner` that:
  - discovers native cases via `getTestNames()` and exposes each as a first-class test (`Description` with real class name + case name — androidx reports these as the `class`/`test` status keys, so ddmlib, Android Studio and Gradle parse them per case instead of one `runNative[]` blob);
  - sanitizes display names for the line-based `INSTRUMENTATION_STATUS` protocol and XML 1.0 (newline/CR → space, other control chars → `?`, collision suffix ` [n]`);
  - throws `AssertionError` with the captured doctest report on failure → lands in the `<failure>` element of `TEST-*.xml` instead of being lost to logcat;
  - fails fast with `InitializationError` when discovery returns nothing;
  - `NativeTestCase` is a Java `record` with compact-constructor null checks.

### CPack metadata
- `CMakeLists.txt` — fixed `HOMEPAGE_URL` (`cxx-skeleton` → `cmake_template`) and replaced the placeholder `DESCRIPTION "My awesome C/C++ project!"` with the real one. `project()` is now the single place to edit package metadata.
- `cmake/description/package_description.cmake` — contact email `glebajk@gmail.com` → `i@egleba.ru`; the CPack long description is now **generated** from `project()` metadata into the build tree via `file(CONFIGURE)` (name, version, homepage, vendor, contact, license) instead of a hand-maintained text file. Everything else (`CPACK_PACKAGE_NAME`, summary, homepage, `.desktop` entry) already derived from `PROJECT_*` and now picks up the fixed values automatically.
- `cmake/description/description.txt` — deleted; it had drifted out of sync with the project and is superseded by the generated file.

### SDL3 warnings
- `cmake/cpm/sdl3-config.cmake` — replaced the ineffective `INTERFACE_SYSTEM_INCLUDE_DIRECTORIES` loop. That property only affects **consuming** translation units (and was redundant even there: CPM's `SYSTEM TRUE` already marks a fetched SDL's interface includes as system, and an imported SDL3 defaults to `SYSTEM`). It never touched the warnings raised while compiling SDL's **own** sources with `SDL_AddCommonCompilerFlags`' aggressive set (`-Wall -Wundef -Wfloat-conversion -Wdocumentation -Wshadow ...`). Now warnings are inhibited directly on SDL's compile-bearing targets (`-w` for GNU/Clang, `/w` for MSVC), enumerated from the fetched tree's `BUILDSYSTEM_TARGETS` so future SDL target renames stay covered. No-op when SDL3 comes from a local package (imported — nothing is compiled).

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes (desktop path untouched — `main.cpp` never set `no-exitcode`)
- [ ] `cmake --workflow --preset=gcc-full` passes (packaging affected: CPack now reads a generated description file)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] `cd android-project && ./gradlew :app:connectedDebugAndroidTest` — each doctest case appears under its own name; a failing case fails with its doctest report in the XML (covered by the `android / instrumented-tests` CI job on this PR)
- [ ] `cmake --workflow --preset=android-arm64-full` — SDL3 compiles with zero warnings from its own sources

## Notes for Reviewer
- JNI signature change: `runTest(String)` `boolean → String`; both sides are updated in this PR, nothing else consumes it.
- The generated description is written with `file(CONFIGURE)`, not `file(GENERATE)`: `include(CPack)` validates `CPACK_PACKAGE_DESCRIPTION_FILE` existence at include time (CPack.cmake:723), so a generate-time write is too late and fails configure with "CPack package description file ... could not be found". `file(CONFIGURE)` writes during configure and only touches the file when content changes.
- The generated `package_description.txt` lands in the build tree, not the source tree; CPack reads it at package time.
- Pre-existing, unchanged: doctest's `--test-case` filter treats `*`/`?` as wildcards, so a native case name containing them could match siblings. Not hit by the current suite — flag if you'd like exact-match escaping in a follow-up.
- Skipped doctest cases (`doctest::skip(true)`) still surface as passed on the JUnit side — same as before; mapping them to JUnit assumptions would need a richer result type across JNI.