### PR TITLE
refactor(cpm): drop the dead SDL3 manifest export

### DIFF
--- a/cmake/cpm/sdl3-config.cmake
+++ b/cmake/cpm/sdl3-config.cmake
@@ -100,10 +100,12 @@ cpmaddpackage(
     "SDL_INSTALL_TESTS OFF"
     "SDL_DISABLE_INSTALL_DOCS ON")
 
-# --- Android: ship SDL's Java bindings + base manifest/proguard -----------
+# --- Android: ship SDL's Java bindings + base proguard rules --------------
 # Configure-time copy from the fetched tree — a build-time target raced
 # AGP's compile*JavaWithJavac. file(COPY/COPY_FILE) without RESULT fail
 # fatally on missing input: no manual existence checks needed.
+# SDL's base AndroidManifest.xml is deliberately NOT exported:
+# manifest.srcFile replaces rather than merges — see app/build.gradle.
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")
     set(sdl3_gen
         "${CMAKE_SOURCE_DIR}/android-project/app/build/generated/sdl3")
@@ -113,11 +115,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Android")
          FILES_MATCHING PATTERN "*.java")
 
     # ONLY_IF_DIFFERENT keeps the timestamp when unchanged: no pointless
-    # Gradle manifest merge on re-configure.
-    file(COPY_FILE
-         "${SDL3_SOURCE_DIR}/android-project/app/src/main/AndroidManifest.xml"
-         "${sdl3_gen}/AndroidManifest.xml"
-         ONLY_IF_DIFFERENT)
+    # R8 re-run on re-configure.
     file(COPY_FILE
          "${SDL3_SOURCE_DIR}/android-project/app/proguard-rules.pro"
          "${sdl3_gen}/proguard-rules.pro"


### PR DESCRIPTION
## Summary

Stop copying SDL's base `AndroidManifest.xml` into `build/generated/sdl3/` — nothing consumes it; the proguard/Java export is unchanged.

## Related Issue

No issue — dead code removal, follow-up to #45.

## Changes

One file: `cmake/cpm/sdl3-config.cmake`, Android export section only.

- **Removed:** the `file(COPY_FILE ... AndroidManifest.xml ...)` half of the export. It was dead on arrival: `app/build.gradle` sets `manifest.srcFile file('src/main/AndroidManifest.xml')` — and `manifest.srcFile` *replaces* the main manifest rather than merging it, so SDL's base manifest is intentionally unused (it declares `android:name="SDLActivity"`, which would resolve against the app namespace to the nonexistent `com.egleba.app.SDLActivity`). Repo-wide search confirms zero references to `build/generated/sdl3/AndroidManifest.xml`.
- **Kept:** the proguard half — that one *is* wired. `release.proguardFiles` in `app/build.gradle` lists `build/generated/sdl3/proguard-rules.pro` between `getDefaultProguardFile('proguard-android-optimize.txt')` and the app's own `proguard-rules.pro`; R8 merges all listed files at minify time. The app's own `proguard-rules.pro` header documents this design ("build.gradle prepends it ahead of this file").
- Comment updated: section banner now says "Java bindings + base proguard rules", and a one-liner records *why* the manifest is not exported so nobody re-adds it.

No behavior change: the copied manifest was never read.

## Verification

- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed

The meaningful check is an `android-*` build: configure (export runs), then `:app:minifyReleaseWithR8` (consumes the proguard copy).

## Notes for Reviewer

The "merge" for proguard lives entirely in AGP/R8 via the `proguardFiles` list — CMake only stages SDL's base file; no merged file is ever produced at configure time. That is the correct split: hand-merging in CMake would pin SDL's rules and break the "bump VERSION/GIT_TAG refreshes both sides" property.
