### PR TITLE
chore(deps): update cursey/safetyhook to 0.7.0

### DIFF
--- a/cmake/cpm/safetyhook-config.cmake
+++ b/cmake/cpm/safetyhook-config.cmake
@@ -4,7 +4,7 @@ cpmaddpackage(
     GITHUB_REPOSITORY
     cursey/safetyhook
     GIT_TAG
-    v0.6.9
+    0.7.0
     EXCLUDE_FROM_ALL
     ON
     OPTIONS


### PR DESCRIPTION
# Pull Request

## Summary
<!-- One sentence: what does this PR do? -->

## Related Issue
<!-- Link: Fixes #123, Closes #456, or "No issue — docs fix." -->

## Changes
<!-- Surgical list: files touched, behavior changed. No fluff. -->

## Verification
<!-- Checklist — tick what you actually ran -->
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed

## Notes for Reviewer
<!-- Anything non-obvious? Breaking changes? Open questions? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SafetyHook dependency to version 0.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->