### PR TITLE
chore(deps): update microsoft/GSL to 4.2.2

### DIFF
--- a/cmake/cpm/gsl-config.cmake
+++ b/cmake/cpm/gsl-config.cmake
@@ -4,7 +4,7 @@ cpmaddpackage(
     GITHUB_REPOSITORY
     microsoft/GSL
     GIT_TAG
-    v4.2.1
+    4.2.2
     GIT_SHALLOW
     TRUE
     GIT_PROGRESS


### PR DESCRIPTION
# Pull Request

## Summary
Updates microsoft/GSL to 4.2.2 (Renovate).

## Related Issue
No issue — dependency bump.

## Changes
- `cmake/cpm/gsl-config.cmake`: GSL 4.2.2

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes

## Notes for Reviewer
Automated Renovate bump.