### PR TITLE
chore(deps): update doctest/doctest to 2.5.3

### DIFF
--- a/cmake/cpm/doctest-config.cmake
+++ b/cmake/cpm/doctest-config.cmake
@@ -4,7 +4,7 @@ cpmaddpackage(
     GITHUB_REPOSITORY
     doctest/doctest
     VERSION
-    2.5.2
+    2.5.3
     GIT_TAG
     v2.5.2
     GIT_SHALLOW


### PR DESCRIPTION
# Pull Request

## Summary
Updates doctest/doctest to 2.5.3 (Renovate).

## Related Issue
No issue — dependency bump.

## Changes
- `cmake/cpm/doctest-config.cmake`: doctest 2.5.3

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes

## Notes for Reviewer
Automated Renovate bump.