### PR TITLE
chore(deps): update androidGradlePlugin to 9.3.2

### DIFF
--- a/android_project/gradle/libs.versions.toml
+++ b/android_project/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 
 [versions]
 # Build system
-androidGradlePlugin = "9.3.1"
+androidGradlePlugin = "9.3.2"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 runner = "1.7.0"


### PR DESCRIPTION
# Pull Request

## Summary
Updates Android Gradle Plugin to 9.3.2 (Renovate).

## Related Issue
No issue — dependency bump.

## Changes
- `android_project/gradle/libs.versions.toml`: androidGradlePlugin 9.3.2

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] Affected cross-compilation presets tested (`android-*`)

## Notes for Reviewer
Automated Renovate bump.