### PR TITLE
chore(deps): update SanderMertens/flecs to 4.1.6

### DIFF
--- a/cmake/cpm/flecs-config.cmake
+++ b/cmake/cpm/flecs-config.cmake
@@ -4,7 +4,7 @@ cpmaddpackage(
     GITHUB_REPOSITORY
     SanderMertens/flecs
     VERSION
-    4.1.5
+    4.1.6
     GIT_TAG
     v4.1.5
     GIT_SHALLOW


### PR DESCRIPTION
# Pull Request

## Summary
Updates SanderMertens/flecs to 4.1.6 (Renovate).

## Related Issue
No issue — dependency bump.

## Changes
- `cmake/cpm/flecs-config.cmake`: flecs 4.1.6

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes

## Notes for Reviewer
Automated Renovate bump.