### PR TITLE
chore(deps): update hoene/libmysofa to 1.3.5

### DIFF
--- a/cmake/cpm/steam_audio-config.cmake
+++ b/cmake/cpm/steam_audio-config.cmake
@@ -34,7 +34,7 @@ cpmaddpackage(
     GITHUB_REPOSITORY
     hoene/libmysofa
     GIT_TAG
-    v1.3.4
+    1.3.5
     SYSTEM
     ON
     GIT_SHALLOW


### PR DESCRIPTION
# Pull Request

## Summary
Updates hoene/libmysofa to 1.3.5 (Renovate).

## Related Issue
No issue — dependency bump.

## Changes
- `cmake/cpm/steam_audio-config.cmake`: libmysofa 1.3.5

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes

## Notes for Reviewer
Automated Renovate bump.