### PR TITLE
chore(deps): update ocornut/imgui to 1.92.9

### DIFF
--- a/cmake/cpm/imgui-config.cmake
+++ b/cmake/cpm/imgui-config.cmake
@@ -2,7 +2,7 @@ cpmaddpackage(
     NAME
     imgui
     VERSION
-    1.92.7
+    1.92.9
     GITHUB_REPOSITORY
     ocornut/imgui
     EXCLUDE_FROM_ALL


### PR DESCRIPTION
# Pull Request

## Summary
Updates ocornut/imgui to 1.92.9 (Renovate).

## Related Issue
No issue — dependency bump.

## Changes
- `cmake/cpm/imgui-config.cmake`: imgui 1.92.9

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes

## Notes for Reviewer
Automated Renovate bump.