### PR TITLE
chore(deps): update lua/lua to 5.5.1

### DIFF
--- a/cmake/cpm/lua_lang-config.cmake
+++ b/cmake/cpm/lua_lang-config.cmake
@@ -4,7 +4,7 @@ cpmaddpackage(
     GIT_REPOSITORY
     https://github.com/lua/lua.git
     VERSION
-    5.5.0
+    5.5.1
     DOWNLOAD_ONLY
     YES)
 


### PR DESCRIPTION
# Pull Request

## Summary
Updates lua/lua to 5.5.1 (Renovate).

## Related Issue
No issue — dependency bump.

## Changes
- `cmake/cpm/lua_lang-config.cmake`: lua 5.5.1

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes

## Notes for Reviewer
Automated Renovate bump.