### PR TITLE
chore(renovate): dependency dashboard, llvm-mingw tracking, unthrottled PR creation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,11 +11,12 @@
   timezone: "UTC",
   schedule: ["before 8am on monday"],
 
-  // PR creation must not be hourly-limited: the self-hosted runner executes
-  // once per week, so a low prHourlyLimit defers the remaining PRs to the
-  // NEXT weekly run. Branch pushes are not capped, PR creation is — that is
-  // how renovate/* branches ended up existing with no PRs attached.
-  // 0 = unlimited per run; prConcurrentLimit still caps simultaneously open PRs.
+  // No hourly PR cap: the self-hosted runner executes once per week, so any
+  // hourly limit trickles PR creation across weekly runs. 0 = unlimited per
+  // run; prConcurrentLimit still caps simultaneously open PRs.
+  // NOTE: if renovate/* branches appear but NO pull requests ever do, the
+  // cause is token permission (403 on PR create), not this limit — see the
+  // token comment in .github/workflows/renovate.yml.
   prHourlyLimit: 0,
   prConcurrentLimit: 10,
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,19 +10,41 @@
   // ─── General ──────────────────────────────────────────────────────────────
   timezone: "UTC",
   schedule: ["before 8am on monday"],
+
+  // PR creation must not be hourly-limited: the self-hosted runner executes
+  // once per week, so a low prHourlyLimit defers the remaining PRs to the
+  // NEXT weekly run. Branch pushes are not capped, PR creation is — that is
+  // how renovate/* branches ended up existing with no PRs attached.
+  // 0 = unlimited per run; prConcurrentLimit still caps simultaneously open PRs.
+  prHourlyLimit: 0,
   prConcurrentLimit: 10,
-  prHourlyLimit: 3,
+
   labels: ["dependencies"],
   commitMessagePrefix: "chore(deps):",
   commitMessageAction: "update",
   commitMessageTopic: "{{depName}}",
   commitMessageExtra: "to {{newValue}}",
 
+  // Never ship zero-day releases: wait 3 days so yanked/broken upstream
+  // releases are filtered out before a PR is even created.
+  minimumReleaseAge: "3 days",
+
+  // ─── Dependency Dashboard ─────────────────────────────────────────────────
+  // Persistent tracking issue listing pending/open/rate-limited updates and
+  // run errors. Tick a checkbox there to force-create any PR on demand —
+  // the Dependabot-like workflow, no CLI required.
+  dependencyDashboard: true,
+  dependencyDashboardTitle: "Renovate dependency dashboard",
+
   // ─── Vulnerability alerts ─────────────────────────────────────────────────
+  // OSV database coverage on top of GitHub advisories.
+  osvVulnerabilityAlerts: true,
   vulnerabilityAlerts: {
     enabled: true,
     schedule: ["at any time"],
     labels: ["dependencies", "security"],
+    // Security fixes bypass the 3-day release-age gate.
+    minimumReleaseAge: null,
   },
 
   // Dependabot owns github-actions + docker updates (see .github/dependabot.yml) —
@@ -42,6 +64,14 @@
       automerge: true,
       automergeStrategy: "squash",
       platformAutomerge: true,
+    },
+    {
+      description:
+        "Group CPM minor updates into one weekly PR (patches stay separate and auto-merge, majors stay isolated)",
+      matchFileNames: ["cmake/cpm/**", "cmake/cpm-config.cmake"],
+      matchUpdateTypes: ["minor"],
+      groupName: "CPM dependencies (minor)",
+      groupSlug: "cpm-minor",
     },
   ],
 
@@ -107,6 +137,23 @@
       datasourceTemplate: "git-refs",
       depNameTemplate: "https://github.com/{{{depName}}}.git",
       currentValueTemplate: "main",
+    },
+
+    // ─── Toolchains ─────────────────────────────────────────────────────────
+    // Matches: set(LLVM_MINGW_VERSION "20260826" ...) in the llvm-mingw
+    // toolchain file. Release tags are bare dates (YYYYMMDD, no v prefix),
+    // so semver-coerced versioning makes them comparable (20260826 ->
+    // 20260826.0.0) while the raw tag is written back as-is.
+    {
+      customType: "regex",
+      description: "llvm-mingw toolchain (LLVM_MINGW_VERSION release tag)",
+      managerFilePatterns: ["/(^|/)cmake/toolchains/llvm_mingw\\.cmake$/"],
+      matchStrings: [
+        "set\\(LLVM_MINGW_VERSION\\s+\"(?<currentValue>[^\"]+)\"",
+      ],
+      depNameTemplate: "mstorsjo/llvm-mingw",
+      datasourceTemplate: "github-releases",
+      versioningTemplate: "semver-coerced",
     },
   ],
 }


### PR DESCRIPTION
# Pull Request

## Summary
Overhauls Renovate into a Dependabot-style, PR-first setup: dependency dashboard, llvm-mingw toolchain tracking, release-age gate, CPM minor grouping.

## Related Issue
No issue — config improvement.

## Changes
All in `.github/renovate.json5`:

- **`dependencyDashboard: true`** — persistent tracking issue with pending/open updates and run errors. Checkbox tick = PR created on demand, no CLI.
- **New customManager: `mstorsjo/llvm-mingw`** — tracks `LLVM_MINGW_VERSION` in `cmake/toolchains/llvm_mingw.cmake` via `github-releases`. Tags are bare dates (`20260826`), so `semver-coerced` versioning makes them comparable while the raw tag is written back unchanged.
- **`minimumReleaseAge: "3 days"`** — zero-day/yanked releases filtered before PR creation; vulnerability alerts exempt (`minimumReleaseAge: null`).
- **`osvVulnerabilityAlerts: true`** — OSV database coverage on top of GitHub advisories.
- **packageRule: group CPM minor updates** into one weekly PR (`renovate/cpm-minor`); patches stay separate and auto-merge, majors stay isolated.
- **`prHourlyLimit: 3 → 0`** — hygiene only, NOT the branches-without-PRs fix (a cap of 3 would still create 3 PRs/run; the observed symptom was zero bot PRs ever). A weekly self-hosted run should not trickle PR creation across runs. See Notes for the actual cause.

## Verification
- [ ] Renovate dry-run validates the config: Actions → Renovate → `workflow_dispatch` with `dryRun=true`
- [ ] "Renovate dependency dashboard" issue appears after the first post-merge run
- [ ] Dashboard lists llvm-mingw under detected dependencies

## Notes for Reviewer
- **Actual root cause of branches-without-PRs: token permission (403 on PR create).** Evidence: every renovate PR in repo history (e.g. #48) was opened manually by @e-gleba from bot-pushed branches — the bot itself has never opened one. Branch push succeeds (`contents: write`), the PR-create call fails.
- **Fix (repo settings, cannot be done in this PR)**: Settings → Actions → General → enable "Allow GitHub Actions to create and approve pull requests", OR set a `RENOVATE_TOKEN` PAT (Contents: RW + Pull requests: RW). The PAT variant also makes CI trigger on bot PRs (GITHUB_TOKEN PRs hit GitHub's recursion guard) and is required for `platformAutomerge` to work.
- Confirm in logs: Actions → Renovate → latest run → search for `403` / `not permitted to create` / `Pull Request`.
- `platformAutomerge` also requires repo setting "Allow auto-merge".
- Merging this PR triggers the Renovate workflow automatically (push path filter on `.github/renovate.json5`) — the merge itself is the live validation.
- Workflow schedule untouched (weekly Monday 06:00 UTC). Optional follow-up: run daily so dashboard checkbox requests are processed faster.