### PR TITLE
chore(ci): add CodeRabbit AI review config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,121 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit AI review — first-pass only: reads code, writes PR comments,
+# never requests changes, never blocks merges (issue #17).
+# Config reference: https://docs.coderabbit.ai/guides/configuration-file
+#
+# Activation: install the CodeRabbit GitHub App on this repo (free for OSS).
+# NOTE: CodeRabbit reads this file from the repository ROOT only —
+# .github/ is not a supported location.
+
+language: en-US
+early_access: false
+
+tone_instructions: |-
+  Concise and technical. No pleasantries, no praise filler.
+  Every finding: problem -> why it matters in this repo -> concrete fix.
+  Follow CLAUDE.md conventions. Suggest nothing beyond the diff's scope:
+  no speculative refactors, no drive-by cleanups.
+
+reviews:
+  profile: chill
+  # Comments only — the bot must never block a merge.
+  request_changes_workflow: false
+  fail_commit_status: false
+  high_level_summary: true
+  collapse_walkthrough: true
+  sequence_diagrams: false
+  poem: false
+  suggested_labels: true
+  suggested_reviewers: false
+  auto_review:
+    enabled: true
+    # Never spam Draft PRs or WIP branches.
+    drafts: false
+    ignore_title_keywords:
+      - wip
+      - draft
+  path_filters:
+    # Generated / vendored trees — never review these.
+    - "!**/build/**"
+    - "!**/_deps/**"
+    - "!.emsdk/**"
+    - "!android_project/.gradle/**"
+    - "!**/node_modules/**"
+  path_instructions:
+    - path: "**/CMakeLists.txt"
+      instructions: >-
+        Modern CMake 4.4+ only: target_* commands over directory/global
+        state — flag include_directories(), add_definitions(), and
+        CMAKE_CXX_FLAGS mutations. Headers belong in
+        target_sources(... FILE_SET ...). CPM.cmake is the only dependency
+        mechanism: flag new find_package calls, conanfile.txt, or
+        vcpkg.json (tracked in issues #3 and #8). Keep FETCHCONTENT_QUIET
+        OFF. Must stay .cmake-format.yaml clean.
+    - path: "cmake/**"
+      instructions: >-
+        Same rules as the root CMakeLists.txt: target_* over globals, no
+        ad-hoc platform hacks — cross-compilation logic lives in presets
+        or cmake/toolchains/*.cmake. warnings.cmake and
+        code_quality.cmake stay per-toolchain and opt-in.
+    - path: "CMakePresets.json"
+      instructions: >-
+        Schema v12, CMake >= 4.4. Naming: '<compiler>-<variant>'
+        configure, '<name>-release/debug' build, '<name>-package' CPack,
+        '<name>-full' workflow. Every native configure preset needs
+        matching build and test presets; cross presets (android-*,
+        llvm-mingw-*) disable test. binaryDir stays build/<preset>.
+        Keep the vendor block minimal.
+    - path: "src/**"
+      instructions: >-
+        C++23/26. Flag missing [[nodiscard]] on non-void public APIs.
+        Prefer std::format/std::print over fmt where the toolchain
+        supports it. No owning raw pointers, no C-style casts. Must stay
+        clang-tidy clean per .clang-tidy.
+    - path: "tests/**"
+      instructions: >-
+        doctest only — flag gtest/catch2 includes. Tests register via
+        doctest_discover_tests() in tests/CMakeLists.txt; CTest preset
+        names mirror build presets (gcc-release, clang-debug, ...).
+    - path: ".github/workflows/**"
+      instructions: >-
+        Every workflow starts with the yaml-language-server schema
+        comment. The build matrix lives only in cmake_multi_platform.yml
+        (workflow_call) — flag duplicated matrix jobs elsewhere. No
+        platform-specific hack scripts in CI: logic belongs in presets or
+        Docker. Pin actions; image names stay
+        ghcr.io/${{ github.repository }}/<name>.
+    - path: "docker/**"
+      instructions: >-
+        Toolchain images only — no source COPY. Pin official base images
+        by explicit tag or digest. New images need a matrix row in
+        publish-docker.yml, never a hardcoded name.
+    - path: "readme.md"
+      instructions: >-
+        Keep under 10 KB. Quick Start <= 3 commands. The comparison table
+        is the only long table allowed. Consulting block stays last; no
+        sponsor badges. Flag stale links — every docs/*.md target must
+        exist.
+  finishing_touches:
+    docstrings:
+      enabled: false
+  tools:
+    actionlint:
+      enabled: true
+    cppcheck:
+      enabled: true
+    gitleaks:
+      enabled: true
+    hadolint:
+      enabled: true
+    markdownlint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    shfmt:
+      enabled: true
+    yamllint:
+      enabled: true
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
# Pull Request

## Summary
Adds a root `.coderabbit.yaml` that configures CodeRabbit as a non-blocking first-pass reviewer tuned to this repo's CMake, C++23/26, preset, and docs conventions.

## Related Issue
Refs #17 — delivers the configuration deliverable. Remaining after merge: installing the CodeRabbit GitHub App (owner-only, UI step) and `docs/coderabbit.md`.

## Changes
Single new file: `.coderabbit.yaml` (repo root). Nothing else touched.

- **Non-blocking by design** — `profile: chill`, `request_changes_workflow: false`, `fail_commit_status: false` → read code, write comments, never gate merges (least-privilege criterion)
- **No spam** — `auto_review.drafts: false` + `ignore_title_keywords: [wip, draft]` → silent on Draft PRs and WIP branches
- **Noise filters** — `path_filters` exclude generated trees (`build/`, `_deps/`, `.emsdk/`, `.gradle/`, `node_modules/`); poem, sequence diagrams, auto-docstrings, and reviewer auto-suggestion disabled
- **Project ruleset** — `path_instructions` encode CLAUDE.md conventions per area:
  - CMake: `target_*` over globals, `FILE_SET` for headers, CPM-only deps (flags `find_package`/`conanfile`/`vcpkg.json` per #3/#8), `.cmake-format.yaml` clean
  - Presets: `<compiler>-<variant>` / `-release|debug` / `-package` / `-full` naming, native presets need matching build+test, cross presets disable test
  - C++: C++23/26, `[[nodiscard]]`, `std::format` over `fmt`, clang-tidy clean
  - Tests: doctest only, `doctest_discover_tests`, CTest names mirror build presets
  - Workflows: schema header comment, single reusable matrix in `cmake_multi_platform.yml`, no CI hack scripts, pinned actions
  - Docker: toolchain-only images, pinned official bases, matrix row in `publish-docker.yml`
  - readme: <10 KB, ≤3-command Quick Start, comparison table only, stale-link detection
- **Linters enabled** — actionlint, hadolint, shellcheck, shfmt, cppcheck, markdownlint, yamllint, gitleaks

## Verification
- [x] YAML written against CodeRabbit schema v2 (`yaml-language-server` header included, matching the workflow-file convention)
- [x] Zero build/CI behavior change — file is inert until the GitHub App is installed
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` — N/A, no CMake/C++ changes
- [ ] `pre-commit run --all-files` — not run (no local checkout); file is plain LF YAML
- [ ] Documentation updated — N/A here; `docs/coderabbit.md` stays tracked in #17

## Notes for Reviewer
- **Placement deviation from the issue:** CodeRabbit reads its config from the **repository root only** — `.github/` is not a supported location and a config there would silently no-op (verified: zero GitHub repos use `.github/.coderabbit.yaml`; [official docs](https://docs.coderabbit.ai/guides/configuration-file) specify root). Placed at root accordingly.
- **Activation is owner-only:** install the [CodeRabbit GitHub App](https://github.com/apps/coderabbitai) on this repo (free for public OSS). Cannot be done via PR/API.
- **Pre-existing drift noticed, not touched (out of scope):** `readme.md` and `CLAUDE.md` reference `docs/*.md`, but no `docs/` directory exists on `main` — those links currently 404.