### PR TITLE
chore: align CodeRabbit with C++23 review rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,10 +12,15 @@ language: en-US
 early_access: false
 
 tone_instructions: |-
-  Concise and technical. No pleasantries, no praise filler.
-  Every finding: problem -> why it matters in this repo -> concrete fix.
-  Follow CLAUDE.md conventions. Suggest nothing beyond the diff's scope:
-  no speculative refactors, no drive-by cleanups.
+  Concise and technical. No pleasantries, praise, or restatement.
+  Put the concrete fix first, then explain the problem and repository impact.
+  Ground C++ claims in primary sources, in order: cppreference, the C++
+  working draft when exact wording matters, compiler-support tables before
+  assuming availability, and Compiler Explorer for generated-code claims.
+  Mark unverified claims as [unverified] and name the check that settles them.
+  Performance claims require generated code or measurements.
+  Follow CLAUDE.md conventions. Review only changed lines and behavior:
+  no speculative abstractions, drive-by cleanup, or unrelated refactors.
 
 reviews:
   profile: chill
@@ -67,16 +72,58 @@ reviews:
         llvm-mingw-*) disable test. binaryDir stays build/<preset>.
         Keep the vendor block minimal.
     - path: "src/**"
-      instructions: >-
-        C++23/26. Flag missing [[nodiscard]] on non-void public APIs.
-        Prefer std::format/std::print over fmt where the toolchain
-        supports it. No owning raw pointers, no C-style casts. Must stay
-        clang-tidy clean per .clang-tidy.
+      instructions: |-
+        Review as C++23 project code. Where these rules conflict with nearby
+        code, follow existing code and report the conflict instead of forcing
+        an unrelated rewrite.
+
+        Review in this order: lifetime and ownership; undefined behavior;
+        uninitialized state and narrowing; concurrency; error paths; public
+        and binary interface impact; measured performance; style last.
+
+        All project-owned declarations live in namespace tb; only main may
+        remain global. Internals use tb::detail and must not leak through
+        public headers. Never add file-scope using namespace directives.
+
+        Use std::int32_t/std::uint32_t/std::int64_t/std::uint64_t with std::
+        qualification for fixed-width values. Use std::size_t for sizes and
+        indices, std::ptrdiff_t for pointer differences, and bare int only
+        when an external API requires it. Prefer initialized declarations,
+        brace initialization, and designated initializers for aggregates.
+        Add final to project types not designed as bases.
+
+        Prefer value semantics, rule of zero, RAII, const by default, and
+        unique ownership. Flag raw owning pointers, new/delete, malloc/free,
+        manual resource cleanup, output parameters where return values work,
+        and stored std::span/std::string_view values that may outlive their
+        backing storage. Shared ownership requires an explicit lifetime need.
+
+        Prefer the standard library, then an already-linked Boost or approved
+        dependency; do not hand-roll tested facilities. Do not add a dependency
+        for a small reusable facility. Prefer algorithms/ranges and named
+        concepts when they improve clarity. Never return a view over a local;
+        remember lazy views re-evaluate on traversal.
+
+        Public results that matter use [[nodiscard]]. Use constexpr where
+        useful at no runtime cost and noexcept only when all reachable work
+        honestly cannot throw. Fallible operations return std::expected or an
+        explicit checked status, never a magic value. Use existing GSL
+        contracts when linked; otherwise prefer the project's dependency-free
+        contract vocabulary. No exceptions across binary boundaries.
+
+        Prefer snake_case for types, functions, variables, and namespaces;
+        reserve UPPER_CASE for macros. Use class for invariant-bearing types,
+        struct for plain data, and ASCII in identifiers and comments. Flag
+        implicit single-argument constructors unless conversion is intended.
+        Keep code clang-tidy clean per .clang-tidy.
     - path: "tests/**"
       instructions: >-
-        doctest only — flag gtest/catch2 includes. Tests register via
-        doctest_discover_tests() in tests/CMakeLists.txt; CTest preset
-        names mirror build presets (gcc-release, clang-debug, ...).
+        Apply the src/** C++23 rules to test helper code. doctest only — flag
+        gtest/catch2 includes. Tests register via doctest_discover_tests() in
+        tests/CMakeLists.txt; CTest preset names mirror build presets
+        (gcc-release, clang-debug, ...). Require changed behavior, error paths,
+        lifetime boundaries, and contract failures to have focused tests;
+        do not request unrelated coverage.
     - path: ".github/workflows/**"
       instructions: >-
         Every workflow starts with the yaml-language-server schema


### PR DESCRIPTION
# Pull Request

## Summary
Upgrade CodeRabbit review guidance to enforce the supplied C++23 `cpp20` rules while preserving the repository's non-blocking, first-pass review policy.

## Related Issue
No issue — review configuration update.

## Changes
- Expand global review tone with source-order, compiler-support, verification, and measured-performance requirements.
- Replace the short `src/**` instruction with focused C++23 guidance for namespace `tb`, fixed-width integers, lifetime/ownership, RAII, value semantics, ranges, concepts, contracts, error handling, naming, and review priority.
- Extend `tests/**` guidance to apply the same C++ rules and request only focused coverage for changed behavior.
- Preserve existing CMake, preset, CI, Docker, documentation, tool, and non-blocking settings.

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed

Configuration-only change. Verified the commit modifies only `.coderabbit.yaml`; no build, packaging, cross-compilation, documentation, or Docker behavior changed. CodeRabbit's v2 schema comment remains enabled for editor/schema validation.

## Notes for Reviewer
The supplied skill is named `cpp20`, but its declared project default is C++23; this PR therefore consistently says C++23. Existing repository-specific rules win when they conflict, and CodeRabbit is instructed to report rather than silently rewrite those conflicts.