### PR TITLE
fix(renovate): stop stability-check 403 from aborting runs before PR creation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,8 +15,10 @@
   // hourly limit trickles PR creation across weekly runs. 0 = unlimited per
   // run; prConcurrentLimit still caps simultaneously open PRs.
   // NOTE: if renovate/* branches appear but NO pull requests ever do, the
-  // cause is token permission (403 on PR create), not this limit — see the
-  // token comment in .github/workflows/renovate.yml.
+  // cause is token permissions, not this limit — see the token comment in
+  // .github/workflows/renovate.yml. Seen so far: 403 on PR create, and 403
+  // on the renovate/stability commit status (minimumReleaseAge below) which
+  // aborts the run pre-PR with "Repository has changed during renovation".
   prHourlyLimit: 0,
   prConcurrentLimit: 10,
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,6 +44,11 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      # renovate/stability commit status (posted because minimumReleaseAge is
+      # set in renovate.json5). Without this the run pushes the branch, then
+      # the 403 on POST /statuses is mapped to REPOSITORY_CHANGED and the run
+      # aborts BEFORE creating any PR — branch appears, PR never does.
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -55,7 +60,9 @@ jobs:
           # Token pushes branches AND opens PRs. If branches appear but PRs
           # never do, check BOTH:
           # - RENOVATE_TOKEN (if set): PAT needs Contents: RW +
-          #   Pull requests: RW on this repo.
+          #   Pull requests: RW + Commit statuses: RW on this repo (the
+          #   statuses perm backs the renovate/stability check; a 403 there
+          #   aborts the run before PR creation).
           # - Fallback GITHUB_TOKEN: repo setting Settings → Actions →
           #   General → "Allow GitHub Actions to create and approve pull
           #   requests" must be checked. Its PRs don't trigger CI
@@ -67,6 +74,6 @@ jobs:
           # Tell Renovate which repository to process
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           # Free tier optimizations
-          RENOVATE_PLATFORM_COMMIT: true
+          RENOVATE_PLATFORM_COMMIT: enabled
           RENOVATE_AUTODISCOVER: false
           RENOVATE_ONBOARDING: false


### PR DESCRIPTION
# Pull Request

## Summary
Fix Renovate runs dying with `Repository has changed during renovation` immediately after pushing a branch — before any PR is created — by granting the job token `statuses: write`, which the `renovate/stability` commit status (triggered by `minimumReleaseAge`) requires.

## Related Issue
No issue — self-hosted Renovate failure. Run log 2026-08-30 18:42 UTC: `renovate/cpm-minor` branch created (`b5b346a`), then the run aborted; PR #59 had to be opened and merged by hand.

## Changes
- `.github/workflows/renovate.yml`
  - `permissions`: add `statuses: write`. Root cause: `minimumReleaseAge: "3 days"` (added in #56) makes Renovate set a `renovate/stability` status check on the branch right after pushing it. The 18:42 run used the fallback `GITHUB_TOKEN` (branch commit authored by `github-actions[bot]`), which lacked this permission → 403 on `POST /statuses` → Renovate's `setBranchStatus` maps any error there to `REPOSITORY_CHANGED` → whole run aborts before `ensurePr` ever runs. Branch appears, PR never does.
  - Token comment: a fine-grained `RENOVATE_TOKEN` PAT also needs **Commit statuses: Read and write**, otherwise the same abort returns on that path.
  - `RENOVATE_PLATFORM_COMMIT: true` → `enabled` — identical behavior, silences the env coercion warning.
- `.github/renovate.json5`
  - Correct the stale `prHourlyLimit` comment: "branch but no PR" is a token-permission symptom (historically 403 on PR create; this time 403 on the stability status), not throttling.

## Verification
- [x] Root cause traced in Renovate source: `lib/workers/repository/update/branch/index.ts` calls `setBranchStatusChecks` right after the `Branch created` log line; `setStability` → `platform.setBranchStatus` (`lib/modules/platform/github/index.ts`) which throws `REPOSITORY_CHANGED` on any status-POST error. Matches the log sequence exactly (`Branch created` → abort, no `Ensuring PR`).
- [x] Ruled out by repo state: no concurrent push to `main` during the run (adjacent commits are 18:36 and 18:46), no pre-existing PR for the branch, and the API-created commit `b5b346a` existed (it merged via #59).
- [x] Merge of this PR touches `.github/workflows/renovate.yml` → the workflow's own `push` trigger fires a Renovate run right after merge; expected result is a clean finish (no `repository-changed`) and bot-opened PRs for any pending updates.
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` — N/A, CI/config only, no CMake or source changes

## Notes for Reviewer
- The `Cannot find replaceString … Was it already updated?` warnings for pybind11/tracy in the failing run were benign: both bumps were applied in the branch (the #59 diff was exactly those two lines). That's a duplicate-match artifact of the regex customManagers within the grouped update, not a permissions issue — worth watching next run, but not blocking.
- The `dryRun`/`platformCommit` "property has been changed" log warnings are benign coercions (`false`→`null` = off, `true`→`enabled`); only `platformCommit` was respelled, `dryRun` left as-is since the dispatch input works.
- If you intend runs to use a PAT rather than `GITHUB_TOKEN`, confirm the `RENOVATE_TOKEN` secret exists — the 18:42 run fell back to `GITHUB_TOKEN`.