### PR TITLE
ci: optimize workflow triggers and naming

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,118 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: android_ci
+
+on:
+  push:
+    branches: [main]
+    paths: &android_paths
+      - "android_project/**"
+      - ".github/workflows/android.yml"
+  pull_request:
+    branches: [main]
+    paths: *android_paths
+  workflow_dispatch:
+
+concurrency:
+  group: android_ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ANDROID_PROJECT_DIR: ${{ github.workspace }}/android_project
+  CPM_SOURCE_CACHE: ${{ github.workspace }}/.cpm_cache
+  GRADLE_OPTS: >-
+    -Dorg.gradle.daemon=false
+    -Dorg.gradle.parallel=true
+    -Dorg.gradle.configureondemand=true
+
+jobs:
+  android_build:
+    name: android_gradle_x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up CMake
+        uses: lukka/get-cmake@v4.4.2
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: temurin
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
+      - name: Cache CPM sources
+        uses: actions/cache@v6
+        with:
+          path: .cpm_cache
+          key: cpm-android-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: cpm-android-
+      - name: Accept Android SDK licenses
+        run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses || true
+      - name: Build release APK
+        working-directory: ${{ env.ANDROID_PROJECT_DIR }}
+        run: gradle --stacktrace :app:assembleRelease
+      - name: Upload release APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: android_gradle_x86_64_release_apk
+          path: ${{ env.ANDROID_PROJECT_DIR }}/app/build/outputs/apk/release/*.apk
+          if-no-files-found: error
+          compression-level: 0
+
+  android_instrumented_test:
+    name: android_emulator_x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up CMake
+        uses: lukka/get-cmake@v4.4.2
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: temurin
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
+      - name: Cache CPM sources
+        uses: actions/cache@v6
+        with:
+          path: .cpm_cache
+          key: cpm-android-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: cpm-android-
+      - name: Accept Android SDK licenses
+        run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses || true
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4ci.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Run instrumented tests
+        uses: ReactiveCircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          arch: x86_64
+          target: default
+          disable-animations: true
+          script: cd ${{ env.ANDROID_PROJECT_DIR }} && gradle --stacktrace :app:connectedDebugAndroidTest --info
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android_emulator_x86_64_test_results
+          path: |
+            ${{ env.ANDROID_PROJECT_DIR }}/app/build/outputs/androidTest-results/
+            ${{ env.ANDROID_PROJECT_DIR }}/app/build/reports/androidTests/
+          if-no-files-found: error
+          compression-level: 0

--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -1,373 +1,200 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: cmake_multiplatform_workflow
+name: cmake_ci
 
 on:
-    push:
-        branches: [main]
-        paths: &paths
-            - "src/**"
-            - "include/**"
-            - "cmake/**"
-            - "**/*.cmake"
-            - "**/*.cpp"
-            - "**/*.hpp"
-            - "**/*.c"
-            - "**/*.h"
-            - "**/*.cxx"
-            - "**/*.hxx"
-            - "**/CMakeLists.txt"
-            - "CMakePresets.json"
-            - ".github/workflows/**"
-            - "android_project/**"
-    pull_request:
-        branches: [main]
-        paths: *paths
-    release:
-        types: [published]
-    workflow_dispatch:
-    # Called by release.yml — same matrix, no duplicated jobs.
-    workflow_call:
+  push:
+    branches: [main]
+    paths: &cmake_paths
+      - "src/**"
+      - "tests/**"
+      - "tools/**"
+      - "scripts/**"
+      - "cmake/**"
+      - "CMakeLists.txt"
+      - "CMakePresets.json"
+      - ".clang-format"
+      - ".clang-tidy"
+      - ".cmake-format.yaml"
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/cmake_multi_platform.yml"
+      - "**/*.cmake"
+      - "**/CMakeLists.txt"
+      - "**/*.c"
+      - "**/*.cc"
+      - "**/*.cpp"
+      - "**/*.cxx"
+      - "**/*.h"
+      - "**/*.hh"
+      - "**/*.hpp"
+      - "**/*.hxx"
+  pull_request:
+    branches: [main]
+    paths: *cmake_paths
+  release:
+    types: [published]
+  workflow_dispatch:
+  workflow_call:
 
-# github.workflow is the *caller* name when this file is reused.
-# Prefix with this file's identity so a release call cannot share
-# a concurrency group with release.yml itself.
 concurrency:
-    group: cmake-multiplatform-${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: cmake_ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
-    contents: read
+  contents: read
 
 env:
-    CPM_SOURCE_CACHE: ${{ github.workspace }}/.cpm_cache
+  CPM_SOURCE_CACHE: ${{ github.workspace }}/.cpm_cache
 
 jobs:
-    # ── native builds ───────────────────────────────────────────
-    native:
-        name: native / ${{ matrix.artifact-name }}
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    - os: ubuntu-latest
-                      preset: clang-full
-                      artifact-name: linux-clang
-                    - os: ubuntu-latest
-                      preset: gcc-full
-                      artifact-name: linux-gcc
-                    - os: windows-2022 # Pin to windows-2022 for VS 2022
-                      preset: msvc-full
-                      artifact-name: windows-msvc
+  native_build:
+    name: ${{ matrix.platform }}_${{ matrix.compiler }}_${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            compiler: clang
+            arch: x86_64
+            preset: clang-full
+            artifact_name: linux_clang_x86_64
+          - os: ubuntu-latest
+            platform: linux
+            compiler: gcc
+            arch: x86_64
+            preset: gcc-full
+            artifact_name: linux_gcc_x86_64
+          - os: windows-2022
+            platform: windows
+            compiler: msvc
+            arch: x86_64
+            preset: msvc-full
+            artifact_name: windows_msvc_x86_64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up CMake and Ninja
+        uses: lukka/get-cmake@v4.4.2
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            clang doxygen graphviz \
+            libwayland-dev libxkbcommon-dev \
+            libegl1-mesa-dev libgles2-mesa-dev libgl1-mesa-dev \
+            libdbus-1-dev libudev-dev libasound2-dev
+      - name: Cache CPM sources
+        uses: actions/cache@v6
+        with:
+          path: .cpm_cache
+          key: cpm-${{ matrix.artifact_name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: cpm-${{ matrix.artifact_name }}-
+      - name: Build and test
+        run: cmake --workflow --preset ${{ matrix.preset }}
+      - name: Build documentation
+        if: matrix.preset == 'clang-full'
+        run: cmake --build --preset clang-docs
+      - name: Verify documentation
+        if: matrix.preset == 'clang-full'
+        shell: bash
+        run: |
+          index_path="build/clang/generated_docs/html/index.html"
+          test -f "${index_path}" || { echo "::error::Documentation index not found at ${index_path}"; exit 1; }
+      - name: Upload documentation
+        if: matrix.preset == 'clang-full'
+        uses: actions/upload-artifact@v7
+        with:
+          name: doxygen_html_${{ github.run_id }}
+          path: build/clang/generated_docs/html/
+          retention-days: 30
+          if-no-files-found: error
+      - name: Upload zip package
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact_name }}_zip
+          path: build/**/*.zip
+          if-no-files-found: ignore
+          compression-level: 0
+      - name: Upload tgz package
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact_name }}_tgz
+          path: build/**/*.tar.gz
+          if-no-files-found: ignore
+          compression-level: 0
 
-        steps:
-            - name: checkout
-              uses: actions/checkout@v7
+  windows_cross_build:
+    name: linux_${{ matrix.compiler }}_${{ matrix.arch }}_to_windows
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - compiler: llvm_mingw
+            arch: x86_64
+            preset: llvm-mingw-x86_64-full
+          - compiler: llvm_mingw
+            arch: i686
+            preset: llvm-mingw-i686-full
+          - compiler: llvm_mingw
+            arch: aarch64
+            preset: llvm-mingw-aarch64-full
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up CMake and Ninja
+        uses: lukka/get-cmake@v4.4.2
+      - name: Cache LLVM MinGW
+        uses: actions/cache@v6
+        with:
+          path: llvm_mingw
+          key: llvm_mingw-${{ hashFiles('cmake/toolchains/llvm_mingw.cmake') }}
+      - name: Cache CPM sources
+        uses: actions/cache@v6
+        with:
+          path: .cpm_cache
+          key: cpm-windows_llvm_mingw_${{ matrix.arch }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: cpm-windows_llvm_mingw_${{ matrix.arch }}-
+      - name: Build and test
+        run: cmake --workflow --preset ${{ matrix.preset }}
+      - name: Upload txz package
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows_llvm_mingw_${{ matrix.arch }}_txz
+          path: build/**/*.tar.xz
+          if-no-files-found: ignore
+          compression-level: 0
 
-            # Presets enforce cmakeMinimumRequired 4.4 — runner images lag
-            # behind Kitware. get-cmake also puts ninja on PATH (cached),
-            # so ninja-build is gone from the apt list below.
-            - name: setup cmake + ninja
-              uses: lukka/get-cmake@v4.4.2
-
-            - name: install linux system deps
-              if: runner.os == 'Linux'
-              run: |
-                  sudo apt-get update -qq
-                  sudo apt-get install -y --no-install-recommends \
-                    clang \
-                    doxygen graphviz \
-                    libwayland-dev libxkbcommon-dev \
-                    libegl1-mesa-dev libgles2-mesa-dev libgl1-mesa-dev \
-                    libdbus-1-dev libudev-dev libasound2-dev
-
-            - name: cache cpm sources
-              uses: actions/cache@v6
-              with:
-                  path: .cpm_cache
-                  key: cpm-${{ matrix.artifact-name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-                  restore-keys: cpm-${{ matrix.artifact-name }}-
-
-            - name: build
-              run: cmake --workflow --preset ${{ matrix.preset }}
-
-            # ── Documentation (Clang only) ───────────────────────────
-            - name: build documentation
-              if: matrix.preset == 'clang-full'
-              run: cmake --build --preset clang-docs
-
-            - name: verify documentation
-              if: matrix.preset == 'clang-full'
-              run: |
-                  index_path="build/clang/generated_docs/html/index.html"
-                  if [[ ! -f "${index_path}" ]]; then
-                    echo "::error::Documentation index not found at ${index_path}"
-                    exit 1
-                  fi
-                  echo "Documentation ready: ${index_path}"
-                  du -sh build/clang/generated_docs/html/
-                  find build/clang/generated_docs/html -maxdepth 1 -type f | sort
-
-            - name: upload documentation artifact
-              if: matrix.preset == 'clang-full'
-              uses: actions/upload-artifact@v7
-              with:
-                  name: doxygen_html_${{ github.run_id }}
-                  path: build/clang/generated_docs/html/
-                  retention-days: 30
-                  if-no-files-found: error
-
-            - name: documentation summary
-              if: matrix.preset == 'clang-full' && always()
-              run: |
-                  {
-                    echo "## Documentation build result"
-                    echo "- Status: ${{ job.status }}"
-                    echo "- Trigger: \`${{ github.event_name }}\`"
-                    echo "- Ref: \`${{ github.ref_name }}\`"
-                    echo "- Preset: \`clang-docs\`"
-                    echo "- Artifact: \`doxygen_html_${{ github.run_id }}\`"
-                  } >> "$GITHUB_STEP_SUMMARY"
-            # ──────────────────────────────────────────────────────────────────
-            - name: upload zip artifact
-              uses: actions/upload-artifact@v7
-              with:
-                  name: ${{ matrix.artifact-name }}-zip
-                  path: build/**/*.zip
-                  if-no-files-found: ignore
-                  compression-level: 0
-
-            - name: upload tgz artifact
-              uses: actions/upload-artifact@v7
-              with:
-                  name: ${{ matrix.artifact-name }}-tgz
-                  path: build/**/*.tar.gz
-                  if-no-files-found: ignore
-                  compression-level: 0
-
-    # ── cross-compile: Linux → Windows (llvm-mingw) ───────────────────────────
-    cross-windows:
-        name: cross-windows / ${{ matrix.artifact-name }}
-        runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    - preset: llvm-mingw-x86_64-full
-                      artifact-name: windows-mingw-x86_64
-                    - preset: llvm-mingw-i686-full
-                      artifact-name: windows-mingw-i686
-                    - preset: llvm-mingw-aarch64-full
-                      artifact-name: windows-mingw-aarch64
-
-        steps:
-            - name: checkout
-              uses: actions/checkout@v7
-
-            # CMake 4.4 + ninja from one cached step — replaces the old
-            # apt ninja-build install.
-            - name: setup cmake + ninja
-              uses: lukka/get-cmake@v4.4.2
-
-            - name: cache llvm-mingw toolchain
-              uses: actions/cache@v6
-              with:
-                  path: llvm_mingw
-                  key: llvm-mingw-${{ hashFiles('cmake/toolchains/llvm_mingw.cmake') }}
-
-            - name: cache cpm sources
-              uses: actions/cache@v6
-              with:
-                  path: .cpm_cache
-                  key: cpm-${{ matrix.artifact-name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-                  restore-keys: cpm-${{ matrix.artifact-name }}-
-
-            - name: build
-              run: cmake --workflow --preset ${{ matrix.preset }}
-
-            - name: upload txz artifact
-              uses: actions/upload-artifact@v7
-              with:
-                  name: ${{ matrix.artifact-name }}-txz
-                  path: build/**/*.tar.xz
-                  if-no-files-found: ignore
-                  compression-level: 0
-
-    # ── cross-compile: Linux → WebAssembly (emscripten) ───────────────────────
-    web:
-        name: web / emscripten
-        runs-on: ubuntu-latest
-        steps:
-            - name: checkout
-              uses: actions/checkout@v7
-
-            # CMake 4.4 + ninja from one cached step — replaces the old
-            # apt ninja-build install.
-            - name: setup cmake + ninja
-              uses: lukka/get-cmake@v4.4.2
-
-            # cmake/toolchains/emscripten.cmake bootstraps the pinned emsdk
-            # into .emsdk/ on first configure — cache it between runs. The key
-            # tracks the toolchain file, so a version bump re-bootstraps.
-            - name: cache emsdk
-              uses: actions/cache@v6
-              with:
-                  path: .emsdk
-                  key: emsdk-${{ hashFiles('cmake/toolchains/emscripten.cmake') }}
-
-            - name: cache cpm sources
-              uses: actions/cache@v6
-              with:
-                  path: .cpm_cache
-                  key: cpm-web-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-                  restore-keys: cpm-web-
-
-            # configure + build + ctest (doctest suite runs under Node.js via
-            # CMAKE_CROSSCOMPILING_EMULATOR — system node or the SDK-bundled
-            # one, wired up by the toolchain wrapper)
-            - name: build and test
-              run: cmake --workflow --preset emscripten-full
-
-            # Self-contained static site — deploy to any static host as-is
-            - name: upload web bundle
-              uses: actions/upload-artifact@v7
-              with:
-                  name: web-emscripten-bundle
-                  path: |
-                      build/emscripten/**/05_webassembly.html
-                      build/emscripten/**/05_webassembly.js
-                      build/emscripten/**/05_webassembly.wasm
-                  if-no-files-found: error
-                  compression-level: 0
-
-    # ── android APK build ────────────────────────────────────────
-    build-apk:
-        name: android / ${{ matrix.build-type }}
-        runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    - build-type: release
-                      gradle-task: assembleRelease
-
-        env:
-            ANDROID_PROJECT_DIR: ${{ github.workspace }}/android_project
-            GRADLE_OPTS: >-
-                -Dorg.gradle.daemon=false
-                -Dorg.gradle.parallel=true
-                -Dorg.gradle.configureondemand=true
-
-        steps:
-            - name: checkout
-              uses: actions/checkout@v7
-
-            # AGP locates CMake on PATH when the SDK ships no matching
-            # package — the SDK's newest cmake (4.1.0) is below the
-            # project's 4.4 floor, so provide it here.
-            - name: setup cmake
-              uses: lukka/get-cmake@v4.4.2
-
-            - name: setup jdk 21
-              uses: actions/setup-java@v5
-              with:
-                  java-version: "21"
-                  distribution: temurin
-
-            - name: setup gradle
-              uses: gradle/actions/setup-gradle@v6.3.0
-              with:
-                  build-scan-publish: true
-                  build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
-                  build-scan-terms-of-use-agree: "yes"
-
-            - name: cache cpm sources
-              uses: actions/cache@v6
-              with:
-                  path: ${{ github.workspace }}/.cpm_cache
-                  key: cpm-android-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-                  restore-keys: cpm-android-
-
-            - name: accept android sdk licenses
-              run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses || true
-
-            - name: build apk
-              working-directory: ${{ env.ANDROID_PROJECT_DIR }}
-              run: gradle --stacktrace :app:${{ matrix.gradle-task }}
-
-            - name: upload apk artifact
-              uses: actions/upload-artifact@v7
-              with:
-                  name: android-${{ matrix.build-type }}-apk
-                  path: ${{ env.ANDROID_PROJECT_DIR }}/app/build/outputs/apk/${{ matrix.build-type }}/*.apk
-                  if-no-files-found: error
-                  compression-level: 0
-
-    # ── android instrumented tests ──────────────────────────────────
-    android-test:
-        name: android / instrumented-tests
-        runs-on: ubuntu-latest
-        env:
-            ANDROID_PROJECT_DIR: ${{ github.workspace }}/android_project
-            GRADLE_OPTS: >-
-                -Dorg.gradle.daemon=false
-                -Dorg.gradle.parallel=true
-                -Dorg.gradle.configureondemand=true
-
-        steps:
-            - name: checkout
-              uses: actions/checkout@v7
-
-            # Same PATH fallback as build-apk: AGP needs CMake >= 4.4,
-            # the SDK's newest package is 4.1.0.
-            - name: setup cmake
-              uses: lukka/get-cmake@v4.4.2
-
-            - name: setup jdk 21
-              uses: actions/setup-java@v5
-              with:
-                  java-version: "21"
-                  distribution: temurin
-
-            - name: setup gradle
-              uses: gradle/actions/setup-gradle@v6.3.0
-              with:
-                  build-scan-publish: true
-                  build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
-                  build-scan-terms-of-use-agree: "yes"
-
-            - name: cache cpm sources
-              uses: actions/cache@v6
-              with:
-                  path: ${{ github.workspace }}/.cpm_cache
-                  key: cpm-android-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-                  restore-keys: cpm-android-
-
-            - name: accept android sdk licenses
-              run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses || true
-
-            - name: enable kvm
-              run: |
-                  echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4ci.rules
-                  sudo udevadm control --reload-rules
-                  sudo udevadm trigger --name-match=kvm
-
-            - name: run instrumented tests
-              uses: ReactiveCircus/android-emulator-runner@v2
-              with:
-                  api-level: 30
-                  arch: x86_64
-                  target: default
-                  disable-animations: true
-                  script: cd ${{ env.ANDROID_PROJECT_DIR }} && gradle --stacktrace :app:connectedDebugAndroidTest --info
-
-            - name: upload test results
-              if: always()
-              uses: actions/upload-artifact@v7
-              with:
-                  name: android-test-results
-                  path: |
-                      ${{ env.ANDROID_PROJECT_DIR }}/app/build/outputs/androidTest-results/
-                      ${{ env.ANDROID_PROJECT_DIR }}/app/build/reports/androidTests/
-                  if-no-files-found: error
-                  compression-level: 0
+  web_build:
+    name: linux_emscripten_wasm32
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up CMake and Ninja
+        uses: lukka/get-cmake@v4.4.2
+      - name: Cache Emscripten SDK
+        uses: actions/cache@v6
+        with:
+          path: .emsdk
+          key: emsdk-${{ hashFiles('cmake/toolchains/emscripten.cmake') }}
+      - name: Cache CPM sources
+        uses: actions/cache@v6
+        with:
+          path: .cpm_cache
+          key: cpm-web_emscripten_wasm32-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          restore-keys: cpm-web_emscripten_wasm32-
+      - name: Build and test
+        run: cmake --workflow --preset emscripten-full
+      - name: Upload web bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: web_emscripten_wasm32_bundle
+          path: |
+            build/emscripten/**/05_webassembly.html
+            build/emscripten/**/05_webassembly.js
+            build/emscripten/**/05_webassembly.wasm
+          if-no-files-found: error
+          compression-level: 0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,73 +1,95 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: docker
+name: docker_ci
 
 on:
   pull_request:
-    paths:
+    paths: &docker_paths
       - "docker/**"
       - ".github/workflows/docker.yml"
   push:
     branches: [main]
-    paths:
-      - "docker/**"
-      - ".github/workflows/docker.yml"
+    paths: *docker_paths
   workflow_dispatch:
 
 concurrency:
-  group: docker-${{ github.ref }}
+  group: docker_ci-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  build:
-    name: ${{ matrix.name }}
+  detect_changes:
+    name: docker_detect_changes
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.changes.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Detect changed Dockerfiles
+        id: changes
+        shell: bash
+        run: |
+          files=(fedora manjaro steamos cachyos alt)
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            changed=("${files[@]}")
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            mapfile -t diff < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+          else
+            mapfile -t diff < <(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}")
+          fi
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            changed=()
+            for name in "${files[@]}"; do
+              if printf '%s\n' "${diff[@]}" | grep -qx "docker/${name}.Dockerfile"; then
+                changed+=("${name}")
+              fi
+            done
+            if printf '%s\n' "${diff[@]}" | grep -qx '.github/workflows/docker.yml'; then
+              changed=("${files[@]}")
+            fi
+          fi
+          matrix=$(printf '%s\n' "${changed[@]}" | jq -R . | jq -sc .)
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+
+  docker_build_and_lint:
+    name: linux_docker_${{ matrix.name }}
+    needs: detect_changes
+    if: needs.detect_changes.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: fedora
-            file: fedora.Dockerfile
-            tools: ninja --version
-          - name: manjaro
-            file: manjaro.Dockerfile
-            tools: ninja --version
-          - name: steamos
-            file: steamos.Dockerfile
-            tools: ninja --version
-          - name: cachyos
-            file: cachyos.Dockerfile
-            tools: ninja --version
-          - name: alt
-            file: alt.Dockerfile
-            tools: make --version
+        name: ${{ fromJSON(needs.detect_changes.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
+      - name: Lint Dockerfile
+        run: docker run --rm -i hadolint/hadolint:v2.15.1 < "docker/${{ matrix.name }}.Dockerfile"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-
-      - name: Build
+      - name: Build image
         uses: docker/build-push-action@v7
         with:
           context: docker
-          file: docker/${{ matrix.file }}
+          file: docker/${{ matrix.name }}.Dockerfile
           load: true
           tags: cmake-template:${{ matrix.name }}
           build-args: SOURCE=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha,scope=docker-${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=docker-${{ matrix.name }}
-
       - name: Verify toolchain
         run: |
-          docker run --rm --entrypoint sh cmake-template:${{ matrix.name }} -c '
+          build_tool="ninja --version"
+          [[ "${{ matrix.name }}" == "alt" ]] && build_tool="make --version"
+          docker run --rm --entrypoint sh cmake-template:${{ matrix.name }} -c "
             cmake --version &&
             git --version &&
             c++ --version &&
             clang++ --version &&
-            ${{ matrix.tools }}
-          '
+            ${build_tool}
+          "

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,37 +1,30 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-#
-# Static checks for GitHub Actions YAML and Dockerfiles.
-# Official images only. Pin tags; Dependabot / Renovate bump them.
-name: lint
+name: workflow_lint
 
 on:
   pull_request:
-    paths:
+    paths: &workflow_paths
       - ".github/workflows/**"
-      - "docker/**"
   push:
     branches: [main]
-    paths:
-      - ".github/workflows/**"
-      - "docker/**"
+    paths: *workflow_paths
   workflow_dispatch:
 
 concurrency:
-  group: lint-${{ github.ref }}
+  group: workflow_lint-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  actionlint:
-    name: actionlint
+  workflow_lint:
+    name: linux_actionlint_x86_64
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
       - name: Lint workflows
         run: |
           docker run --rm \
@@ -39,25 +32,3 @@ jobs:
             -w /repo \
             rhysd/actionlint:1.7.12 \
             -color
-
-  hadolint:
-    name: hadolint
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    strategy:
-      fail-fast: false
-      matrix:
-        file:
-          - docker/fedora.Dockerfile
-          - docker/manjaro.Dockerfile
-          - docker/steamos.Dockerfile
-          - docker/cachyos.Dockerfile
-          - docker/alt.Dockerfile
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Lint ${{ matrix.file }}
-        run: |
-          docker run --rm -i hadolint/hadolint:v2.15.1 \
-            < "${{ matrix.file }}"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,39 +1,34 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: nix
+name: nix_ci
 
 on:
   pull_request:
-    paths:
+    paths: &nix_paths
       - "nix/**"
       - ".github/workflows/nix.yml"
   push:
     branches: [main]
-    paths:
-      - "nix/**"
-      - ".github/workflows/nix.yml"
+    paths: *nix_paths
   workflow_dispatch:
 
 concurrency:
-  group: nix-${{ github.ref }}
+  group: nix_ci-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  build:
-    name: flake and OCI image
+  nix_build:
+    name: linux_nix_x86_64
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
       - name: Install Nix
         uses: cachix/install-nix-action@v31
-
       - name: Check flake
         run: nix flake check ./nix --no-write-lock-file
-
       - name: Build OCI image
         run: nix build ./nix#docker --no-link --no-write-lock-file

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,20 +1,18 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-#
-# Publish toolchain images to GHCR after Docker changes reach main.
-name: publish-docker
+name: docker_publish
 
 on:
   workflow_call:
     inputs:
       tag:
-        description: Extra image tag (in addition to latest / sha)
+        description: Extra image tag
         required: false
         type: string
         default: ""
   workflow_dispatch:
     inputs:
       tag:
-        description: Extra image tag (in addition to latest / sha)
+        description: Extra image tag
         required: false
         type: string
         default: ""
@@ -25,7 +23,7 @@ on:
       - ".github/workflows/publish-docker.yml"
 
 concurrency:
-  group: publish-docker-${{ github.workflow }}-${{ github.ref }}
+  group: docker_publish-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -39,39 +37,26 @@ env:
   EXTRA_TAG: ${{ inputs.tag || '' }}
 
 jobs:
-  publish:
-    name: ${{ matrix.name }}
+  docker_publish:
+    name: linux_docker_${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: fedora
-            file: fedora.Dockerfile
-          - name: manjaro
-            file: manjaro.Dockerfile
-          - name: steamos
-            file: steamos.Dockerfile
-          - name: cachyos
-            file: cachyos.Dockerfile
-          - name: alt
-            file: alt.Dockerfile
+        name: [fedora, manjaro, steamos, cachyos, alt]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker metadata
+      - name: Generate Docker metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -81,12 +66,11 @@ jobs:
             type=raw,value=${{ env.EXTRA_TAG }},enable=${{ env.EXTRA_TAG != '' }}
             type=sha,prefix=sha-
             type=ref,event=branch
-
-      - name: Build and push
+      - name: Build and push image
         uses: docker/build-push-action@v7
         with:
           context: docker
-          file: docker/${{ matrix.file }}
+          file: docker/${{ matrix.name }}.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -95,13 +79,3 @@ jobs:
           build-args: SOURCE=${{ github.server_url }}/${{ github.repository }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
-
-      - name: Summary
-        if: always()
-        run: |
-          {
-            echo "## ${{ matrix.name }}"
-            echo "- Status: \`${{ job.status }}\`"
-            echo "- Image: \`${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.name }}\`"
-            echo "- Tags: \`${{ steps.meta.outputs.tags }}\`"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,37 +1,27 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: Renovate
+name: renovate
 
 on:
-  # Manual trigger from GitHub UI
   workflow_dispatch:
     inputs:
-      dryRun:
-        description: 'Dry run (no PRs created)'
+      dry_run:
+        description: Dry run
         required: false
         default: false
         type: boolean
-      logLevel:
-        description: 'Log level'
+      log_level:
+        description: Log level
         required: false
         default: info
         type: choice
-        options:
-          - debug
-          - info
-          - warn
-          - error
-
-  # Schedule: weekly on Monday at 6am UTC
+        options: [debug, info, warn, error]
   schedule:
-    - cron: '0 6 * * 1'
-
-  # Also run on pushes to main that touch renovate config
+    - cron: "0 6 * * 1"
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
-      - '.github/renovate.json5'
-      - '.github/workflows/renovate.yml'
+      - ".github/renovate.json5"
+      - ".github/workflows/renovate.yml"
 
 concurrency:
   group: renovate-${{ github.ref }}
@@ -39,41 +29,25 @@ concurrency:
 
 jobs:
   renovate:
+    name: linux_renovate_x86_64
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
       issues: write
-      # renovate/stability commit status (posted because minimumReleaseAge is
-      # set in renovate.json5). Without this the run pushes the branch, then
-      # the 403 on POST /statuses is mapped to REPOSITORY_CHANGED and the run
-      # aborts BEFORE creating any PR — branch appears, PR never does.
       statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Self-hosted Renovate
+      - name: Run Renovate
         uses: renovatebot/github-action@v46.2.2
         with:
           configurationFile: .github/renovate.json5
-          # Token pushes branches AND opens PRs. If branches appear but PRs
-          # never do, check BOTH:
-          # - RENOVATE_TOKEN (if set): PAT needs Contents: RW +
-          #   Pull requests: RW + Commit statuses: RW on this repo (the
-          #   statuses perm backs the renovate/stability check; a 403 there
-          #   aborts the run before PR creation).
-          # - Fallback GITHUB_TOKEN: repo setting Settings → Actions →
-          #   General → "Allow GitHub Actions to create and approve pull
-          #   requests" must be checked. Its PRs don't trigger CI
-          #   workflows (GitHub recursion guard).
           token: ${{ secrets.RENOVATE_TOKEN || secrets.GITHUB_TOKEN }}
         env:
-          RENOVATE_DRY_RUN: ${{ github.event.inputs.dryRun || 'false' }}
-          LOG_LEVEL: ${{ github.event.inputs.logLevel || 'info' }}
-          # Tell Renovate which repository to process
+          RENOVATE_DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          LOG_LEVEL: ${{ inputs.log_level || 'info' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          # Free tier optimizations
           RENOVATE_PLATFORM_COMMIT: enabled
           RENOVATE_AUTODISCOVER: false
           RENOVATE_ONBOARDING: false


### PR DESCRIPTION
# Pull Request

## Summary
Make CI workflow naming consistent and restrict each pipeline to relevant changes.

## Related Issue
No issue — CI cleanup.

## Changes
- Use snake_case workflow, job, matrix, artifact, and concurrency names.
- Split Android CI from the general CMake matrix so Android-only changes run only Android CI.
- Limit CMake CI to C/C++/CMake inputs and its own workflow definition.
- Merge Dockerfile lint and image build into one per-image job.
- Detect changed Dockerfiles and run only their matrix entries; workflow edits or manual runs validate all images.
- Keep workflow YAML lint separate and trigger it only for workflow changes.
- Preserve narrow Nix, Docker publish, and Renovate triggers while normalizing names.
- Use descriptive platform_compiler_arch check names.

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed

CI validates workflow syntax and affected Docker images on this PR.

## Notes for Reviewer
No merge requested. PR intentionally left open for review.