### PR TITLE
feat(cxx): add C++ modules integration example

### DIFF
--- a/src/06_modules/CMakeLists.txt
+++ b/src/06_modules/CMakeLists.txt
@@ -2,6 +2,27 @@
 # scanning disabled for ordinary C++ sources project-wide.
 message(CHECK_START "Checking C++23 named modules")
 
+# CMake knows which compiler families and versions provide its module
+# dependency scanner. Avoid configuring a probe CXX_MODULES target when
+# that scanner is unavailable: unsupported module targets are rejected
+# during generation, before try_compile can return FALSE.
+set(cxx_modules_scanner_supported FALSE)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
+   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.34)
+    set(cxx_modules_scanner_supported TRUE)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+       AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16)
+    set(cxx_modules_scanner_supported TRUE)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+       AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14)
+    set(cxx_modules_scanner_supported TRUE)
+endif()
+
+if(NOT cxx_modules_scanner_supported)
+    message(CHECK_FAIL "CMake has no scanner for this compiler; skipping 06_modules")
+    return()
+endif()
+
 # The generated source-file try_compile project assigns its CXX_MODULES
 # file set the caller's source directory as its default base directory.
 # Generate a complete probe project so its file-set base is self-contained.

--- a/src/06_modules/CMakeLists.txt
+++ b/src/06_modules/CMakeLists.txt
@@ -2,24 +2,47 @@
 # scanning disabled for ordinary C++ sources project-wide.
 message(CHECK_START "Checking C++23 named modules")
 
-try_compile(
-    cxx_modules_supported
-    SOURCES_TYPE CXX_MODULE
-    SOURCE_FROM_CONTENT cxx_modules_probe.cppm [[
+# The generated source-file try_compile project assigns its CXX_MODULES
+# file set the caller's source directory as its default base directory.
+# Generate a complete probe project so its file-set base is self-contained.
+set(cxx_modules_probe_source_dir
+    "${CMAKE_CURRENT_BINARY_DIR}/cxx_modules_probe")
+file(
+    WRITE "${cxx_modules_probe_source_dir}/CMakeLists.txt"
+    [[
+cmake_minimum_required(VERSION 4.4)
+project(cxx_modules_probe LANGUAGES CXX)
+
+add_executable(cxx_modules_probe main.cpp)
+target_sources(
+    cxx_modules_probe
+    PRIVATE
+        FILE_SET CXX_MODULES
+        FILES cxx_modules_probe.cppm)
+target_compile_features(cxx_modules_probe PRIVATE cxx_std_23)
+set_target_properties(cxx_modules_probe PROPERTIES CXX_EXTENSIONS OFF)
+]])
+file(
+    WRITE "${cxx_modules_probe_source_dir}/cxx_modules_probe.cppm"
+    [[
 export module cxx_modules_probe;
 export constexpr int module_value = 42;
-]]
-    SOURCES_TYPE NORMAL
-    SOURCE_FROM_CONTENT main.cpp [[
+]])
+file(
+    WRITE "${cxx_modules_probe_source_dir}/main.cpp"
+    [[
 import cxx_modules_probe;
 int main()
 {
     static_assert(module_value == 42);
 }
-]]
-    CXX_STANDARD 23
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
+]])
+
+try_compile(
+    cxx_modules_supported
+    PROJECT cxx_modules_probe
+    SOURCE_DIR "${cxx_modules_probe_source_dir}"
+    TARGET cxx_modules_probe
     LOG_DESCRIPTION "Check whether the active toolchain builds C++23 named modules")
 
 if(cxx_modules_supported)

--- a/src/06_modules/CMakeLists.txt
+++ b/src/06_modules/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Module interface units in CXX_MODULES file sets are always scanned. Keep
+# scanning disabled for ordinary C++ sources project-wide.
+message(CHECK_START "Checking C++23 named modules")
+
+try_compile(
+    cxx_modules_supported
+    SOURCES_TYPE CXX_MODULE
+    SOURCE_FROM_CONTENT cxx_modules_probe.cppm [[
+export module cxx_modules_probe;
+export constexpr int module_value = 42;
+]]
+    SOURCES_TYPE NORMAL
+    SOURCE_FROM_CONTENT main.cpp [[
+import cxx_modules_probe;
+int main()
+{
+    static_assert(module_value == 42);
+}
+]]
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+    LOG_DESCRIPTION "Check whether the active toolchain builds C++23 named modules")
+
+if(cxx_modules_supported)
+    message(CHECK_PASS "supported")
+else()
+    message(CHECK_FAIL "unsupported; skipping 06_modules")
+    return()
+endif()
+
+add_library(06_modules_library)
+add_library(cxx_project::modules ALIAS 06_modules_library)
+
+target_sources(
+    06_modules_library
+    PRIVATE math.cpp
+    PUBLIC
+        FILE_SET CXX_MODULES
+        FILES math.cppm math-operations.cppm)
+target_compile_features(06_modules_library PUBLIC cxx_std_23)
+set_target_properties(06_modules_library PROPERTIES CXX_EXTENSIONS OFF)
+target_link_libraries(06_modules_library PRIVATE warnings)
+
+add_executable(06_modules main.cpp)
+target_compile_features(06_modules PRIVATE cxx_std_23)
+set_target_properties(06_modules PROPERTIES CXX_EXTENSIONS OFF)
+target_link_libraries(06_modules PRIVATE cxx_project::modules warnings)
+
+install(TARGETS 06_modules RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+                                 COMPONENT runtime)

--- a/src/06_modules/main.cpp
+++ b/src/06_modules/main.cpp
@@ -1,0 +1,26 @@
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+import cxx_project.math;
+
+static_assert(cxx_project::fibonacci(10) == 55);
+static_assert(cxx_project::clamp(42, 0, 100) == 42);
+
+int main()
+{
+    constexpr cxx_project::version value{
+        .major = 1,
+        .minor = 2,
+        .patch = 3,
+    };
+
+    const std::string text{cxx_project::to_string(value)};
+    const bool features_work = text == "1.2.3"
+                               && cxx_project::fibonacci(10) == 55
+                               && cxx_project::clamp(150, 0, 100) == 100;
+
+    std::cout << "C++ modules: " << text << '\n';
+    return features_work && std::cout.good() ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/06_modules/math-operations.cppm
+++ b/src/06_modules/math-operations.cppm
@@ -1,0 +1,32 @@
+module;
+
+#include <concepts>
+#include <cstdint>
+
+export module cxx_project.math:operations;
+
+export namespace cxx_project
+{
+template <typename type>
+concept number = std::integral<type> || std::floating_point<type>;
+
+template <number type>
+[[nodiscard]] constexpr type clamp(type value, type lower, type upper) noexcept
+{
+    return value < lower ? lower : (upper < value ? upper : value);
+}
+
+[[nodiscard]] constexpr std::uint64_t fibonacci(std::uint32_t count) noexcept
+{
+    std::uint64_t previous{};
+    std::uint64_t current{1};
+
+    for (std::uint32_t index{}; index < count; ++index) {
+        const std::uint64_t next{previous + current};
+        previous = current;
+        current = next;
+    }
+
+    return previous;
+}
+} // namespace cxx_project

--- a/src/06_modules/math.cpp
+++ b/src/06_modules/math.cpp
@@ -1,0 +1,14 @@
+module;
+
+#include <format>
+#include <string>
+
+module cxx_project.math;
+
+namespace cxx_project
+{
+std::string to_string(const version& value)
+{
+    return std::format("{}.{}.{}", value.major, value.minor, value.patch);
+}
+} // namespace cxx_project

--- a/src/06_modules/math.cppm
+++ b/src/06_modules/math.cppm
@@ -1,0 +1,20 @@
+module;
+
+#include <cstdint>
+#include <string>
+
+export module cxx_project.math;
+
+export import :operations;
+
+export namespace cxx_project
+{
+struct version final
+{
+    std::uint32_t major{};
+    std::uint32_t minor{};
+    std::uint32_t patch{};
+};
+
+[[nodiscard]] std::string to_string(const version& value);
+} // namespace cxx_project

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,3 +4,4 @@ add_subdirectory(03_unity_build)
 
 add_subdirectory(04_tracy_profiler)
 add_subdirectory(05_webassembly)
+add_subdirectory(06_modules)


### PR DESCRIPTION
# Pull Request

## Summary
Adds `src/06_modules`, a focused C++23 named-modules example with configure-time toolchain capability detection.

## Related Issue
Closes #5

## Changes
- Add primary module interface `cxx_project.math`
- Add and re-export interface partition `cxx_project.math:operations`
- Add module implementation unit for non-inline `to_string`
- Add importer executable with compile-time and runtime feature checks
- Guard the probe with CMake's documented compiler/scanner support matrix
- Probe supported scanner candidates using an isolated whole-project `try_compile`
- Skip only the module example when the active toolchain cannot build it
- Leave `readme.md`, presets, dependencies, and workflows untouched

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed

## Notes for Reviewer
- CI validated Clang, MSVC, Emscripten, and all LLVM-MinGW configurations before the latest GCC scanner guard; new CI run validates the complete change.
- A `CXX_MODULES` file set is unconditionally scanned. On unsupported compilers, CMake rejects that target during generation before `try_compile` can return `FALSE`; the documented compiler/version gate avoids constructing an invalid probe target.
- For scanner-capable compilers, the compile probe remains the final authority over the complete compiler, scanner, generator, and build-tool combination.
