### PR TITLE
refactor(cmake): namespace project-owned CMake API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ project(
 # No C++20 modules in use — do not pay for the module dependency scan.
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
+# Project-owned CMake names use CT_* for user-facing cache variables and
+# options, and ct_* for targets, functions, properties, and local variables.
+# Built-in and dependency-owned names keep their upstream spelling.
+
 # Project modules, loaded by name via include(). CMAKE_CURRENT_LIST_DIR
 # (not CMAKE_SOURCE_DIR) keeps this correct when the project is consumed
 # via add_subdirectory()/FetchContent.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
+    "$schema": "https://json.schemastore.org/cmake-presets.json",
     "version": 12,
     "cmakeMinimumRequired": {
         "major": 4,

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json.schemastore.org/cmake-presets.json",
+    "$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
     "version": 12,
     "cmakeMinimumRequired": {
         "major": 4,

--- a/cmake/cpm/imgui-config.cmake
+++ b/cmake/cpm/imgui-config.cmake
@@ -15,100 +15,87 @@ cpmaddpackage(
 include_guard(GLOBAL)
 
 # imgui ships no build system of its own, so its libraries are defined here:
-#   imgui::imgui        - context, widgets, draw lists (platform-agnostic)
-#   imgui::sdl3_opengl3 - SDL3 platform + OpenGL3 renderer backend
+#   ct::imgui              - context, widgets, draw lists
+#   ct::imgui_sdl3_opengl3 - SDL3 platform + OpenGL3 renderer backend
+#   ct::imgui_sdl3_renderer - SDL3 platform + SDL_Renderer backend
 #
-# Both are EXCLUDE_FROM_ALL: imgui is only compiled where a target actually
+# All are EXCLUDE_FROM_ALL: imgui is only compiled where a target actually
 # links it (currently the Emscripten web_app) - native builds skip it.
 
 add_library(
-    imgui STATIC EXCLUDE_FROM_ALL
+    ct_imgui STATIC EXCLUDE_FROM_ALL
     ${imgui_SOURCE_DIR}/imgui.cpp
     ${imgui_SOURCE_DIR}/imgui_demo.cpp
     ${imgui_SOURCE_DIR}/imgui_draw.cpp
     ${imgui_SOURCE_DIR}/imgui_tables.cpp
     ${imgui_SOURCE_DIR}/imgui_widgets.cpp
     ${imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp)
-add_library(imgui::imgui ALIAS imgui)
+add_library(ct::imgui ALIAS ct_imgui)
 target_include_directories(
-    imgui SYSTEM PUBLIC $<BUILD_INTERFACE:${imgui_SOURCE_DIR}>
-                        $<BUILD_INTERFACE:${imgui_SOURCE_DIR}/misc/cpp>)
-target_compile_features(imgui PUBLIC cxx_std_23)
+    ct_imgui SYSTEM PUBLIC $<BUILD_INTERFACE:${imgui_SOURCE_DIR}>
+                           $<BUILD_INTERFACE:${imgui_SOURCE_DIR}/misc/cpp>)
+target_compile_features(ct_imgui PUBLIC cxx_std_23)
 
 # FreeType rasterizer is opt-in: imgui_freetype.cpp hard-includes
-# <ft2build.h>, so it is only compiled when the Freetype::Freetype target
-# already exists (e.g. after find_package(freetype2_upstream) - see
-# cmake/cpm/freetype-config.cmake). No find_package here: the dependency is
-# optional and absent on Emscripten.
-if(TARGET Freetype::Freetype)
-    target_sources(imgui
-                   PRIVATE ${imgui_SOURCE_DIR}/misc/freetype/imgui_freetype.cpp)
+# <ft2build.h>, so it is only compiled when CT_IMGUI_FREETYPE is enabled.
+if(CT_IMGUI_FREETYPE)
+    find_package(freetype CONFIG REQUIRED)
+    target_sources(
+        ct_imgui PRIVATE ${imgui_SOURCE_DIR}/misc/freetype/imgui_freetype.cpp)
     # PUBLIC because imgui_freetype.h exposes FreeType types to consumers.
-    target_link_libraries(imgui PUBLIC Freetype::Freetype)
+    target_link_libraries(ct_imgui PUBLIC Freetype::Freetype)
     target_include_directories(
-        imgui SYSTEM
+        ct_imgui SYSTEM
         PUBLIC $<BUILD_INTERFACE:${imgui_SOURCE_DIR}/misc/freetype>)
-    target_compile_definitions(imgui PUBLIC IMGUI_ENABLE_FREETYPE)
+    target_compile_definitions(ct_imgui PUBLIC IMGUI_ENABLE_FREETYPE)
 endif()
 
-# SDL3 + OpenGL3 renderer backend. Built when SDL3 is present and we are
-# either on Emscripten or a desktop OpenGL target is available.
-#
-# OpenGL is linked only when the OpenGL::GL target already exists (desktop GL
-# via find_package(OpenGL) called before this config runs). On Emscripten the
-# GLES3/WebGL2 symbols come from the emcc link flags on the final executable
-# (-sUSE_WEBGL2=1 -sFULL_ES3=1), so no OpenGL target is needed there.
-#
-# Platform packages needed for the desktop find_package(OpenGL):
-#   Windows : vcpkg install opengl --triplet=x64-windows
-#   Fedora  : sudo dnf install mesa-libGL-devel mesa-libGLU-devel
-#   Arch    : sudo pacman -S mesa glu
-#   Ubuntu  : sudo apt-get install libgl1-mesa-dev libglu1-mesa-dev
-#   macOS   : OpenGL.framework is included in the SDK
-if(TARGET SDL3::SDL3 AND (EMSCRIPTEN OR TARGET OpenGL::GL))
+# SDL3 + OpenGL3 renderer backend. Built when requested; Emscripten gets
+# GLES3/WebGL2 symbols from final executable link flags, while native builds
+# need the standard OpenGL imported target.
+if(CT_IMGUI_SDL3_OPENGL3)
+    if(NOT TARGET SDL3::SDL3)
+        message(FATAL_ERROR
+                "CT_IMGUI_SDL3_OPENGL3 requires the SDL3::SDL3 target")
+    endif()
+    if(NOT EMSCRIPTEN)
+        find_package(OpenGL REQUIRED)
+    endif()
+
     add_library(
-        imgui_sdl3_opengl3 STATIC EXCLUDE_FROM_ALL
+        ct_imgui_sdl3_opengl3 STATIC EXCLUDE_FROM_ALL
         ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
         ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl3.cpp)
-    add_library(imgui::sdl3_opengl3 ALIAS imgui_sdl3_opengl3)
+    add_library(ct::imgui_sdl3_opengl3 ALIAS ct_imgui_sdl3_opengl3)
     target_include_directories(
-        imgui_sdl3_opengl3 SYSTEM
+        ct_imgui_sdl3_opengl3 SYSTEM
         PUBLIC $<BUILD_INTERFACE:${imgui_SOURCE_DIR}/backends>)
-    target_compile_features(imgui_sdl3_opengl3 PUBLIC cxx_std_23)
-    # The OpenGL3 backend defaults to ES2 on Emscripten - force GLES3.
+    target_compile_features(ct_imgui_sdl3_opengl3 PUBLIC cxx_std_23)
     target_compile_definitions(
-        imgui_sdl3_opengl3
+        ct_imgui_sdl3_opengl3
         PRIVATE $<$<PLATFORM_ID:Emscripten>:IMGUI_IMPL_OPENGL_ES3>)
-    target_link_libraries(imgui_sdl3_opengl3 PUBLIC imgui::imgui SDL3::SDL3)
-    # Link desktop OpenGL only when its target actually exists. A genexp
-    # cannot be used here: it would name OpenGL::GL unconditionally and fail
-    # at generate time when the target was never created.
+    target_link_libraries(ct_imgui_sdl3_opengl3 PUBLIC ct::imgui SDL3::SDL3)
     if(TARGET OpenGL::GL)
-        target_link_libraries(imgui_sdl3_opengl3 PUBLIC OpenGL::GL)
+        target_link_libraries(ct_imgui_sdl3_opengl3 PUBLIC OpenGL::GL)
     endif()
 endif()
 
 # SDL3 renderer backend: stock imgui_impl_sdl3 + imgui_impl_sdlrenderer3.
-# Needs no OpenGL development files — SDL3 loads the platform graphics
-# APIs (Direct3D/Vulkan/OpenGL/software) dynamically at runtime, so the
-# executable stays self-contained. Works for native and cross builds.
-if(TARGET SDL3::SDL3 AND ct_sdl_render)
-    add_library(imgui_sdl3_renderer STATIC EXCLUDE_FROM_ALL )
-    add_library(imgui::sdl3_renderer ALIAS imgui_sdl3_renderer)
+if(CT_IMGUI_SDL3_RENDERER)
+    if(NOT CT_SDL_RENDER)
+        message(FATAL_ERROR
+                "CT_IMGUI_SDL3_RENDERER requires CT_SDL_RENDER=ON")
+    endif()
 
+    add_library(ct_imgui_sdl3_renderer STATIC EXCLUDE_FROM_ALL)
+    add_library(ct::imgui_sdl3_renderer ALIAS ct_imgui_sdl3_renderer)
     target_sources(
-        imgui_sdl3_renderer
+        ct_imgui_sdl3_renderer
         PRIVATE ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl3.cpp
                 ${imgui_SOURCE_DIR}/backends/imgui_impl_sdlrenderer3.cpp)
-
-    # Backends include <imgui.h> and <imgui_impl_*.h>.
-    # imgui::imgui already exposes ${imgui_SOURCE_DIR}; we only need the
-    # backends directory here.
     target_include_directories(
-        imgui_sdl3_renderer SYSTEM
+        ct_imgui_sdl3_renderer SYSTEM
         PUBLIC $<BUILD_INTERFACE:${imgui_SOURCE_DIR}/backends>)
-
-    target_link_libraries(imgui_sdl3_renderer PUBLIC imgui::imgui SDL3::SDL3)
-
-    target_compile_features(imgui_sdl3_renderer PUBLIC cxx_std_23)
+    target_link_libraries(ct_imgui_sdl3_renderer PUBLIC ct::imgui SDL3::SDL3)
+    target_compile_features(ct_imgui_sdl3_renderer PUBLIC cxx_std_23)
 endif()

--- a/cmake/cpm/imgui-config.cmake
+++ b/cmake/cpm/imgui-config.cmake
@@ -14,45 +14,37 @@ cpmaddpackage(
 # scopes, but the libraries below may only be defined once.
 include_guard(GLOBAL)
 
-# imgui ships no build system of its own, so its libraries are defined here:
-#   ct::imgui              - context, widgets, draw lists
-#   ct::imgui_sdl3_opengl3 - SDL3 platform + OpenGL3 renderer backend
-#   ct::imgui_sdl3_renderer - SDL3 platform + SDL_Renderer backend
-#
-# All are EXCLUDE_FROM_ALL: imgui is only compiled where a target actually
-# links it (currently the Emscripten web_app) - native builds skip it.
-
+# Canonical reusable ImGui target. This is the portable upstream core plus
+# imgui_stdlib; consumers can copy this config without inheriting this
+# template's renderer choices.
 add_library(
-    ct_imgui STATIC EXCLUDE_FROM_ALL
+    imgui STATIC EXCLUDE_FROM_ALL
     ${imgui_SOURCE_DIR}/imgui.cpp
     ${imgui_SOURCE_DIR}/imgui_demo.cpp
     ${imgui_SOURCE_DIR}/imgui_draw.cpp
     ${imgui_SOURCE_DIR}/imgui_tables.cpp
     ${imgui_SOURCE_DIR}/imgui_widgets.cpp
     ${imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp)
-add_library(ct::imgui ALIAS ct_imgui)
+add_library(imgui::imgui ALIAS imgui)
 target_include_directories(
-    ct_imgui SYSTEM PUBLIC $<BUILD_INTERFACE:${imgui_SOURCE_DIR}>
-                           $<BUILD_INTERFACE:${imgui_SOURCE_DIR}/misc/cpp>)
-target_compile_features(ct_imgui PUBLIC cxx_std_23)
+    imgui SYSTEM PUBLIC $<BUILD_INTERFACE:${imgui_SOURCE_DIR}>
+                        $<BUILD_INTERFACE:${imgui_SOURCE_DIR}/misc/cpp>)
+target_compile_features(imgui PUBLIC cxx_std_23)
 
-# FreeType rasterizer is opt-in: imgui_freetype.cpp hard-includes
-# <ft2build.h>, so it is only compiled when CT_IMGUI_FREETYPE is enabled.
+# FreeType extends canonical ImGui core rather than creating a project wrapper.
 if(CT_IMGUI_FREETYPE)
     find_package(freetype CONFIG REQUIRED)
-    target_sources(
-        ct_imgui PRIVATE ${imgui_SOURCE_DIR}/misc/freetype/imgui_freetype.cpp)
-    # PUBLIC because imgui_freetype.h exposes FreeType types to consumers.
-    target_link_libraries(ct_imgui PUBLIC Freetype::Freetype)
+    target_sources(imgui
+                   PRIVATE ${imgui_SOURCE_DIR}/misc/freetype/imgui_freetype.cpp)
+    target_link_libraries(imgui PUBLIC Freetype::Freetype)
     target_include_directories(
-        ct_imgui SYSTEM
+        imgui SYSTEM
         PUBLIC $<BUILD_INTERFACE:${imgui_SOURCE_DIR}/misc/freetype>)
-    target_compile_definitions(ct_imgui PUBLIC IMGUI_ENABLE_FREETYPE)
+    target_compile_definitions(imgui PUBLIC IMGUI_ENABLE_FREETYPE)
 endif()
 
-# SDL3 + OpenGL3 renderer backend. Built when requested; Emscripten gets
-# GLES3/WebGL2 symbols from final executable link flags, while native builds
-# need the standard OpenGL imported target.
+# Project-selected integration targets combine upstream ImGui with renderer
+# and platform libraries, so they live under the ct:: namespace.
 if(CT_IMGUI_SDL3_OPENGL3)
     if(NOT TARGET SDL3::SDL3)
         message(FATAL_ERROR
@@ -74,13 +66,12 @@ if(CT_IMGUI_SDL3_OPENGL3)
     target_compile_definitions(
         ct_imgui_sdl3_opengl3
         PRIVATE $<$<PLATFORM_ID:Emscripten>:IMGUI_IMPL_OPENGL_ES3>)
-    target_link_libraries(ct_imgui_sdl3_opengl3 PUBLIC ct::imgui SDL3::SDL3)
+    target_link_libraries(ct_imgui_sdl3_opengl3 PUBLIC imgui::imgui SDL3::SDL3)
     if(TARGET OpenGL::GL)
         target_link_libraries(ct_imgui_sdl3_opengl3 PUBLIC OpenGL::GL)
     endif()
 endif()
 
-# SDL3 renderer backend: stock imgui_impl_sdl3 + imgui_impl_sdlrenderer3.
 if(CT_IMGUI_SDL3_RENDERER)
     if(NOT CT_SDL_RENDER)
         message(FATAL_ERROR
@@ -96,6 +87,6 @@ if(CT_IMGUI_SDL3_RENDERER)
     target_include_directories(
         ct_imgui_sdl3_renderer SYSTEM
         PUBLIC $<BUILD_INTERFACE:${imgui_SOURCE_DIR}/backends>)
-    target_link_libraries(ct_imgui_sdl3_renderer PUBLIC ct::imgui SDL3::SDL3)
+    target_link_libraries(ct_imgui_sdl3_renderer PUBLIC imgui::imgui SDL3::SDL3)
     target_compile_features(ct_imgui_sdl3_renderer PUBLIC cxx_std_23)
 endif()

--- a/cmake/cpm/sdl3-config.cmake
+++ b/cmake/cpm/sdl3-config.cmake
@@ -1,79 +1,68 @@
 # SDL3 package config — find_package(sdl3 CONFIG) lands here via
-# CMAKE_PREFIX_PATH (cmake/cpm.cmake). Exposes SDL's own targets:
+# CMAKE_PREFIX_PATH. Exposes SDL's own targets unchanged:
 #   SDL3::SDL3, SDL3::SDL3-shared, SDL3::SDL3-static
-# Aliases are created by SDL's CMakeLists — nothing to re-name here.
 
-# find_package re-includes this file per calling scope; run once.
 include_guard(GLOBAL)
 
+option(CT_SDL_RENDER "Build SDL3 renderer subsystem" OFF)
+option(CT_IMGUI_FREETYPE "Build Dear ImGui FreeType rasterizer" OFF)
+option(CT_IMGUI_SDL3_OPENGL3 "Build Dear ImGui SDL3 + OpenGL3 backend" OFF)
+option(CT_IMGUI_SDL3_RENDERER "Build Dear ImGui SDL3 renderer backend" OFF)
+
 # --- platform-conditional subsystems: defaults, then overrides ------------
-set(sdl_sensor OFF) # mobile-only subsystem
-set(sdl_wayland OFF) # Linux desktop integration:
-set(sdl_dbus OFF) #   Wayland, D-Bus, IBus, libdecor
-set(sdl_ibus OFF)
-set(sdl_libdecor OFF)
-set(sdl_opengles ON) # Apple uses desktop GL, not ES
-set(sdl_shared ON) # Emscripten has no dynamic linking: static-only
-set(sdl_static OFF)
-set(ct_sdl_render OFF)
+set(ct_sdl_sensor OFF)
+set(ct_sdl_wayland OFF)
+set(ct_sdl_dbus OFF)
+set(ct_sdl_ibus OFF)
+set(ct_sdl_libdecor OFF)
+set(ct_sdl_opengles ON)
+set(ct_sdl_shared ON)
+set(ct_sdl_static OFF)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set(sdl_sensor ON)
+    set(ct_sdl_sensor ON)
 endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(sdl_wayland ON)
-    set(sdl_dbus ON)
-    set(sdl_ibus ON)
-    set(sdl_libdecor ON)
+    set(ct_sdl_wayland ON)
+    set(ct_sdl_dbus ON)
+    set(ct_sdl_ibus ON)
+    set(ct_sdl_libdecor ON)
 endif()
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin|iOS")
-    set(sdl_opengles OFF)
+    set(ct_sdl_opengles OFF)
 endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
-    set(sdl_shared OFF)
-    set(sdl_static ON)
+    set(ct_sdl_shared OFF)
+    set(ct_sdl_static ON)
 endif()
 
-# --- fetch SDL3: windowing, events, OpenGL context creation only ----------
 cpmaddpackage(
-    NAME
-    SDL3
-    GITHUB_REPOSITORY
-    libsdl-org/SDL
-    VERSION
-    3.4.14
-    GIT_TAG
-    release-3.4.14
-    GIT_SHALLOW
-    ON
-    GIT_PROGRESS
-    ON
-    EXCLUDE_FROM_ALL
-    TRUE
-    SYSTEM
-    TRUE
+    NAME SDL3
+    GITHUB_REPOSITORY libsdl-org/SDL
+    VERSION 3.4.14
+    GIT_TAG release-3.4.14
+    GIT_SHALLOW ON
+    GIT_PROGRESS ON
+    EXCLUDE_FROM_ALL TRUE
+    SYSTEM TRUE
     OPTIONS
-    # ---- build tooling ----
     "SDL_CCACHE ON"
-    "SDL_WERROR OFF" # dep warnings must never become errors in our build
-    "SDL_PCH OFF" # goes stale on incremental Android Studio builds
-    # ---- library type ----
-    "SDL_STATIC ${sdl_static}"
-    "SDL_SHARED ${sdl_shared}"
-    # ---- core subsystems ----
+    "SDL_WERROR OFF"
+    "SDL_PCH OFF"
+    "SDL_STATIC ${ct_sdl_static}"
+    "SDL_SHARED ${ct_sdl_shared}"
     "SDL_AUDIO OFF"
     "SDL_VIDEO ON"
     "SDL_GPU OFF"
-    "SDL_RENDER ${ct_sdl_render}"
+    "SDL_RENDER ${CT_SDL_RENDER}"
     "SDL_CAMERA OFF"
     "SDL_JOYSTICK OFF"
     "SDL_HAPTIC OFF"
     "SDL_HIDAPI OFF"
     "SDL_POWER OFF"
-    "SDL_SENSOR ${sdl_sensor}"
-    # ---- video backends ----
+    "SDL_SENSOR ${ct_sdl_sensor}"
     "SDL_X11 ON"
-    "SDL_WAYLAND ${sdl_wayland}"
+    "SDL_WAYLAND ${ct_sdl_wayland}"
     "SDL_KMSDRM OFF"
     "SDL_RPI OFF"
     "SDL_ROCKCHIP OFF"
@@ -81,19 +70,15 @@ cpmaddpackage(
     "SDL_DUMMYVIDEO OFF"
     "SDL_OFFSCREEN OFF"
     "SDL_OPENVR OFF"
-    # ---- context APIs ----
     "SDL_OPENGL ON"
-    "SDL_OPENGLES ${sdl_opengles}"
-    # ---- Linux desktop integration ----
-    "SDL_DBUS ${sdl_dbus}"
-    "SDL_IBUS ${sdl_ibus}"
-    "SDL_WAYLAND_LIBDECOR ${sdl_libdecor}"
-    # ---- input / misc ----
+    "SDL_OPENGLES ${ct_sdl_opengles}"
+    "SDL_DBUS ${ct_sdl_dbus}"
+    "SDL_IBUS ${ct_sdl_ibus}"
+    "SDL_WAYLAND_LIBDECOR ${ct_sdl_libdecor}"
     "SDL_LIBUDEV OFF"
     "SDL_HIDAPI_LIBUSB OFF"
     "SDL_HIDAPI_JOYSTICK OFF"
     "SDL_VIRTUAL_JOYSTICK OFF"
-    # ---- tests / examples / install ----
     "SDL_TESTS OFF"
     "SDL_TEST_LIBRARY OFF"
     "SDL_EXAMPLES OFF"
@@ -101,29 +86,22 @@ cpmaddpackage(
     "SDL_INSTALL_TESTS OFF"
     "SDL_DISABLE_INSTALL_DOCS ON")
 
-# --- Android: ship SDL's Java bindings + base manifest/proguard -----------
-# Configure-time copy from the fetched tree — a build-time target raced
-# AGP's compile*JavaWithJavac. file(COPY/COPY_FILE) without RESULT fail
-# fatally on missing input: no manual existence checks needed.
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")
-    set(sdl3_gen "${CMAKE_SOURCE_DIR}/android_project/app/build/generated/sdl3")
-
+    set(ct_sdl3_gen
+        "${CMAKE_SOURCE_DIR}/android_project/app/build/generated/sdl3")
     file(
         COPY "${SDL3_SOURCE_DIR}/android-project/app/src/main/java/org/"
-        DESTINATION "${sdl3_gen}/java/org"
+        DESTINATION "${ct_sdl3_gen}/java/org"
         FILES_MATCHING
         PATTERN "*.java")
-
-    # ONLY_IF_DIFFERENT keeps the timestamp when unchanged: no pointless
-    # Gradle manifest merge on re-configure.
     file(
         COPY_FILE
         "${SDL3_SOURCE_DIR}/android-project/app/src/main/AndroidManifest.xml"
-        "${sdl3_gen}/AndroidManifest.xml"
+        "${ct_sdl3_gen}/AndroidManifest.xml"
         ONLY_IF_DIFFERENT)
     file(
         COPY_FILE
         "${SDL3_SOURCE_DIR}/android-project/app/proguard-rules.pro"
-        "${sdl3_gen}/proguard-rules.pro"
+        "${ct_sdl3_gen}/proguard-rules.pro"
         ONLY_IF_DIFFERENT)
 endif()

--- a/cmake/ct_cpm.cmake
+++ b/cmake/ct_cpm.cmake
@@ -4,14 +4,14 @@
 
 include(FetchContent)
 
-# NOTE: no URL_HASH on purpose. Renovate bumps cpm_version but cannot
+# NOTE: no URL_HASH on purpose. Renovate bumps ct_cpm_version but cannot
 # recompute a hash — a stale hash fails the configure step harder than
 # no hash. Same trust model as the GIT_TAG-pinned deps below.
-set(cpm_version "0.43.1")
+set(ct_cpm_version "0.43.1")
 
 fetchcontent_declare(
     get_cpm
-    URL "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${cpm_version}/CPM.cmake"
+    URL "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${ct_cpm_version}/CPM.cmake"
     DOWNLOAD_NO_EXTRACT TRUE)
 
 fetchcontent_makeavailable(get_cpm)
@@ -28,13 +28,13 @@ if(CPM_SOURCE_CACHE)
     file(WRITE "${CPM_SOURCE_CACHE}/.clang-tidy" "Checks: '-*'\n")
 endif()
 
-set(cpm_deps_dir "${CMAKE_CURRENT_LIST_DIR}/cpm")
+set(ct_cpm_deps_dir "${CMAKE_CURRENT_LIST_DIR}/cpm")
 
-list(APPEND CMAKE_PREFIX_PATH "${cpm_deps_dir}")
+list(APPEND CMAKE_PREFIX_PATH "${ct_cpm_deps_dir}")
 if(CMAKE_CROSSCOMPILING)
     # Toolchains may scope find_package() to CMAKE_FIND_ROOT_PATH
     # (CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY) — keep our configs reachable.
-    list(APPEND CMAKE_FIND_ROOT_PATH "${cpm_deps_dir}")
+    list(APPEND CMAKE_FIND_ROOT_PATH "${ct_cpm_deps_dir}")
 endif()
 
 find_package(doctest CONFIG REQUIRED)

--- a/cmake/presets/web.json
+++ b/cmake/presets/web.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json.schemastore.org/cmake-presets.json",
+    "$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
     "version": 12,
     "include": ["base.json"],
     "configurePresets": [

--- a/cmake/presets/web.json
+++ b/cmake/presets/web.json
@@ -1,9 +1,9 @@
 {
-    "$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
+    "$schema": "https://json.schemastore.org/cmake-presets.json",
     "version": 12,
     "include": ["base.json"],
     "configurePresets": [
-        {"name": "web_emscripten_wasm32", "displayName": "Web Emscripten wasm32", "description": "WebAssembly build with Emscripten; tests run with Node.js", "inherits": "base", "toolchainFile": "${sourceDir}/cmake/toolchains/emscripten.cmake", "cacheVariables": {"CMAKE_CXX_CLANG_TIDY": ""}}
+        {"name": "web_emscripten_wasm32", "displayName": "Web Emscripten wasm32", "description": "WebAssembly build with Emscripten; tests run with Node.js", "inherits": "base", "toolchainFile": "${sourceDir}/cmake/toolchains/emscripten.cmake", "cacheVariables": {"CMAKE_CXX_CLANG_TIDY": "", "CT_IMGUI_SDL3_OPENGL3": "ON"}}
     ],
     "buildPresets": [
         {"name": "web_emscripten_wasm32_release", "configurePreset": "web_emscripten_wasm32", "inherits": "build_release"},

--- a/src/05_webassembly/CMakeLists.txt
+++ b/src/05_webassembly/CMakeLists.txt
@@ -2,26 +2,16 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     return()
 endif()
 # WebAssembly deploy target - SDL3 + OpenGL (WebGL2) + Dear ImGui demo.
-#
-# Entered only when configuring with the Emscripten toolchain (see the
-# `emscripten` preset in CMakePresets.json), so this file stays free of
-# platform conditionals. Output: `05_webassembly.{html,js,wasm}` - a fully static
-# site, deployable to any web server as-is.
 
 add_executable(05_webassembly main.cpp)
-
 set_target_properties(05_webassembly PROPERTIES SUFFIX ".html")
-
 target_compile_features(05_webassembly PRIVATE cxx_std_23)
 
-# Target names match the rest of the project (see src/CMakeLists.txt):
-#   imgui::sdl3_opengl3 - Dear ImGui SDL3+OpenGL3 backend (cmake/cpm/imgui-config.cmake)
-#   Microsoft.GSL::GSL  - GSL v4.x exported alias
 target_link_libraries(
     05_webassembly
     PRIVATE warnings
             SDL3::SDL3-static
-            imgui::sdl3_opengl3
+            ct::imgui_sdl3_opengl3
             Microsoft.GSL::GSL)
 
 target_link_options(
@@ -33,6 +23,5 @@ target_link_options(
     -sMAX_WEBGL_VERSION=2
     -sFULL_ES3=1
     -sALLOW_MEMORY_GROWTH=1
-    # extra runtime checks in debug builds, zero release cost
     "$<$<CONFIG:Debug>:-sASSERTIONS=2>"
     "$<$<CONFIG:Debug>:-sGL_ASSERTIONS=1>")


### PR DESCRIPTION
# Pull Request

## Summary

Apply `CT_*`, `ct_*`, and `ct::*` to project-owned CMake knobs, locals, and integration targets while preserving canonical dependency APIs.

## Related Issue

Progresses #58.

## Changes

- Rename project bootstrap locals to `ct_cpm_version` and `ct_cpm_deps_dir`.
- Add explicit `CT_SDL_RENDER`, `CT_IMGUI_FREETYPE`, `CT_IMGUI_SDL3_OPENGL3`, and `CT_IMGUI_SDL3_RENDERER` options.
- Prefix project-owned SDL configuration locals with `ct_sdl_*`.
- Preserve canonical upstream/dependency targets: `imgui::imgui`, `SDL3::SDL3`, `Freetype::Freetype`, and `OpenGL::GL`.
- Namespace only project-specific composed integrations: `ct::imgui_sdl3_opengl3` and `ct::imgui_sdl3_renderer`.
- Update the WebAssembly consumer to link the composed `ct::` integration.
- Keep the repository's strict direct CMake preset schema URLs unchanged.
- Fail clearly when requested integrations lack required targets or options.

## Verification

- [ ] Native workflow
- [ ] Emscripten workflow
- [ ] Cross workflows
- [ ] pre-commit

## Notes for Reviewer

Breaking names are limited to project-owned configuration and composed renderer integrations. Canonical dependency targets remain portable and familiar.
