### PR TITLE
fix: publish LLVM-MinGW and Emscripten release assets

### DIFF
--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -110,19 +110,21 @@ jobs:
           path: build/linux_clang_x86_64/generated_docs/html/
           retention-days: 30
           if-no-files-found: error
-      - name: Upload zip package
+      - name: Stage release assets
+        shell: bash
+        env:
+          BUILD_DIR: build/${{ matrix.artifact_name }}
+        run: |
+          cmake \
+            -DBUILD_DIR="${BUILD_DIR}" \
+            -DSTAGING_DIR="${RUNNER_TEMP}/release-assets" \
+            -P cmake/scripts/stage_release_assets.cmake
+      - name: Upload release assets
         uses: actions/upload-artifact@v7
         with:
-          name: release-asset-${{ matrix.artifact_name }}-zip
-          path: build/${{ matrix.artifact_name }}/*.zip
-          if-no-files-found: ignore
-          compression-level: 0
-      - name: Upload tgz package
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-asset-${{ matrix.artifact_name }}-tgz
-          path: build/${{ matrix.artifact_name }}/*.tar.gz
-          if-no-files-found: ignore
+          name: release-assets-${{ matrix.artifact_name }}
+          path: ${{ runner.temp }}/release-assets/
+          if-no-files-found: error
           compression-level: 0
 
   windows_cross_build:
@@ -135,12 +137,15 @@ jobs:
           - compiler: llvm_mingw
             arch: x86_64
             preset: windows_llvm_mingw_x86_64_release_package
+            build_dir: windows_llvm_mingw_x86_64
           - compiler: llvm_mingw
             arch: i686
             preset: windows_llvm_mingw_x86_release_package
+            build_dir: windows_llvm_mingw_x86
           - compiler: llvm_mingw
             arch: aarch64
             preset: windows_llvm_mingw_aarch64_release_package
+            build_dir: windows_llvm_mingw_aarch64
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -159,12 +164,20 @@ jobs:
           restore-keys: cpm-windows_llvm_mingw_${{ matrix.arch }}-
       - name: Build and test
         run: cmake --workflow --preset ${{ matrix.preset }}
-      - name: Upload txz package
+      - name: Stage release assets
+        env:
+          BUILD_DIR: build/${{ matrix.build_dir }}
+        run: |
+          cmake \
+            -DBUILD_DIR="${BUILD_DIR}" \
+            -DSTAGING_DIR="${RUNNER_TEMP}/release-assets" \
+            -P cmake/scripts/stage_release_assets.cmake
+      - name: Upload release assets
         uses: actions/upload-artifact@v7
         with:
-          name: release-asset-windows-llvm-mingw-${{ matrix.arch }}-txz
-          path: build/windows_llvm_mingw_${{ matrix.arch }}/*.tar.xz
-          if-no-files-found: ignore
+          name: release-assets-windows-llvm-mingw-${{ matrix.arch }}
+          path: ${{ runner.temp }}/release-assets/
+          if-no-files-found: error
           compression-level: 0
 
   web_build:
@@ -188,13 +201,22 @@ jobs:
           restore-keys: cpm-web_emscripten_wasm32-
       - name: Build and test
         run: cmake --workflow --preset web_emscripten_wasm32_release_test
-      - name: Upload web bundle
+      - name: Package web application
+        shell: bash
+        run: |
+          mapfile -t web_files < <(find build/web_emscripten_wasm32 -type f \
+            \( -name '05_webassembly.html' -o -name '05_webassembly.js' -o -name '05_webassembly.wasm' \) \
+            -print | sort)
+          if (( ${#web_files[@]} != 3 )); then
+            printf '::error::expected html, JavaScript, and WebAssembly outputs; found %d\n' "${#web_files[@]}"
+            exit 1
+          fi
+          cmake -E tar cf "${RUNNER_TEMP}/release-assets/cxx_project-Web_Emscripten_wasm32.zip" \
+            --format=zip -- "${web_files[@]}"
+      - name: Upload release assets
         uses: actions/upload-artifact@v7
         with:
-          name: web_emscripten_wasm32_bundle
-          path: |
-            build/web_emscripten_wasm32/**/05_webassembly.html
-            build/web_emscripten_wasm32/**/05_webassembly.js
-            build/web_emscripten_wasm32/**/05_webassembly.wasm
+          name: release-assets-web-emscripten-wasm32
+          path: ${{ runner.temp }}/release-assets/
           if-no-files-found: error
           compression-level: 0

--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -211,7 +211,9 @@ jobs:
             printf '::error::expected html, JavaScript, and WebAssembly outputs; found %d\n' "${#web_files[@]}"
             exit 1
           fi
-          cmake -E tar cf "${RUNNER_TEMP}/release-assets/cxx_project-Web_Emscripten_wasm32.zip" \
+          staging_dir="${RUNNER_TEMP}/release-assets"
+          mkdir -p "${staging_dir}"
+          cmake -E tar cf "${staging_dir}/cxx_project-Web_Emscripten_wasm32.zip" \
             --format=zip -- "${web_files[@]}"
       - name: Upload release assets
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,22 +81,22 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: release-assets
-          pattern: release-asset-*
+          pattern: release-assets-*
           merge-multiple: true
 
       - name: Verify release assets
         shell: bash
         run: |
           shopt -s nullglob
-          files=(release-assets/*)
-          if (( ${#files[@]} == 0 )); then
+          assets=(release-assets/*)
+          if (( ${#assets[@]} == 0 )); then
             echo "::error::no release assets were downloaded"
             exit 1
           fi
 
           {
-            echo "## Release assets (${#files[@]})"
-            printf -- '- %s\n' "${files[@]#release-assets/}"
+            echo "## Release assets (${#assets[@]})"
+            printf -- '- %s\n' "${assets[@]#release-assets/}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Create GitHub Release
@@ -104,7 +104,7 @@ jobs:
           PRERELEASE: ${{ inputs.prerelease }}
         run: |
           shopt -s nullglob
-          files=(release-assets/*)
+          assets=(release-assets/*)
           args=(
             "${VERSION}"
             --repo "${{ github.repository }}"
@@ -115,7 +115,7 @@ jobs:
           if [ "${PRERELEASE}" = "true" ]; then
             args+=(--prerelease)
           fi
-          gh release create "${args[@]}" "${files[@]}"
+          gh release create "${args[@]}" "${assets[@]}"
           echo "Created ${{ github.server_url }}/${{ github.repository }}/releases/tag/${VERSION}" \
             >> "$GITHUB_STEP_SUMMARY"
 

--- a/cmake/scripts/stage_release_assets.cmake
+++ b/cmake/scripts/stage_release_assets.cmake
@@ -1,0 +1,37 @@
+if(NOT DEFINED BUILD_DIR OR BUILD_DIR STREQUAL "")
+    message(FATAL_ERROR "BUILD_DIR is required")
+endif()
+
+if(NOT DEFINED STAGING_DIR OR STAGING_DIR STREQUAL "")
+    message(FATAL_ERROR "STAGING_DIR is required")
+endif()
+
+if(NOT IS_DIRECTORY "${BUILD_DIR}")
+    message(FATAL_ERROR "build directory does not exist: ${BUILD_DIR}")
+endif()
+
+file(GLOB package_candidates LIST_DIRECTORIES FALSE "${BUILD_DIR}/*")
+set(package_files)
+foreach(candidate IN LISTS package_candidates)
+    if(candidate MATCHES "\\.(zip|tar\\.gz|tar\\.xz|apk)$")
+        list(APPEND package_files "${candidate}")
+    endif()
+endforeach()
+
+list(LENGTH package_files package_count)
+if(package_count EQUAL 0)
+    message(FATAL_ERROR "no release package found in ${BUILD_DIR}")
+endif()
+
+file(REMOVE_RECURSE "${STAGING_DIR}")
+file(MAKE_DIRECTORY "${STAGING_DIR}")
+
+foreach(package_file IN LISTS package_files)
+    get_filename_component(package_name "${package_file}" NAME)
+    configure_file(
+        "${package_file}"
+        "${STAGING_DIR}/${package_name}"
+        COPYONLY)
+endforeach()
+
+message(STATUS "staged ${package_count} release asset(s) from ${BUILD_DIR}")


### PR DESCRIPTION
## Problem

The release contract only included artifacts whose Actions artifact names matched `release-assets-*`.

LLVM-MinGW package uploads depended on workflow-maintained build-directory spellings, and the Emscripten output used a separate `web_emscripten_wasm32_bundle` artifact outside the release namespace. Therefore WebAssembly never reached the GitHub Release, while cross-package discovery was brittle and could silently upload nothing because package upload used `if-no-files-found: ignore`.

## Fix

### One release-artifact contract

Every releasable build now:

1. stages final files in `${RUNNER_TEMP}/release-assets`
2. uploads exactly one `release-assets-<platform>` artifact
3. uses `if-no-files-found: error`

The publisher downloads all `release-assets-*` artifacts with `actions/download-artifact@v8`, merges them into one directory, and publishes every staged file. It has no platform list and no extension allowlist.

### Flexible CPack discovery

Added `cmake/scripts/stage_release_assets.cmake`:

- accepts a build directory and staging directory
- discovers package files only at the CPack output root
- excludes internal `_CPack_Packages` trees structurally
- supports ZIP, TGZ, TXZ, and APK packages
- fails when a package job produced no releasable output
- keeps release publishing independent of generated package filenames

The LLVM-MinGW matrix now carries each preset's build directory as matrix data, including the important `x86` versus `i686` distinction.

### Emscripten release package

The three deployed web files (`.html`, `.js`, `.wasm`) are verified and packaged into one ZIP. That ZIP enters the same release contract as native and cross-compiled packages.

## Expected GitHub Release assets

- Linux Clang TGZ
- Linux GCC TGZ
- Windows MSVC ZIP
- Windows LLVM-MinGW x86 TXZ
- Windows LLVM-MinGW x86_64 TXZ
- Windows LLVM-MinGW AArch64 TXZ
- Emscripten wasm32 ZIP

Actual CPack filenames remain generated by CMake/CPack; the release workflow does not hardcode them.

## Reliability and efficiency

- Missing output fails in producing job, not late in release publication.
- No recursive scan of implementation-detail package directories.
- No duplicate canonical/internal CPack assets.
- One upload per build job reduces repeated artifact-action setup.
- Existing parallel matrix, caches, scoped triggers, and concurrency behavior remain unchanged.
- Documentation remains a CI artifact but is intentionally not a release asset.

## Validation

- Actionlint runs for workflow changes.
- Full build matrix runs because the reusable staging script and package workflow changed.
- Release publisher still rejects an empty merged asset set before creating a release.