### PR TITLE
fix(cmake): use cmake_template as project name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 4.4)
 
 project(
-    cxx_project
+    cmake_template
     VERSION 1.0.0
     DESCRIPTION "Production-ready cross-platform C++ project template"
     HOMEPAGE_URL "https://github.com/e-gleba/cmake_template"


### PR DESCRIPTION
# Pull Request

## Summary
Set the top-level CMake project name to `cmake_template` instead of `cxx_project`.

## Related Issue
No issue — project metadata fix.

## Changes
- Change only the `project()` name in the root `CMakeLists.txt`: `cxx_project` → `cmake_template`.

## Verification
- [ ] `cmake --preset=linux_gcc_x86_64 && cmake --build --preset=linux_gcc_x86_64_release && ctest --preset=linux_gcc_x86_64_release` passes
- [ ] `cmake --workflow --preset=linux_gcc_x86_64_release_package` passes
- [ ] `pre-commit run --all-files` passes
- [ ] Affected cross-compilation presets tested
- [ ] Documentation updated
- [ ] `docker build` succeeds if Dockerfiles changed

Not run: one-line CMake metadata rename; CI will verify configuration/build behavior.

## Notes for Reviewer
C++ module names and namespaces remain `cxx_project`; request targets only the CMake `project()` name.