### PR TITLE
fix(ci): repair CMake version regexes and modernize release workflow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,16 +11,12 @@
 language: en-US
 early_access: false
 
+# Schema cap: 250 characters. Currently 237.
 tone_instructions: |-
-  Concise and technical. No pleasantries, praise, or restatement.
-  Put the concrete fix first, then explain the problem and repository impact.
-  Ground C++ claims in primary sources, in order: cppreference, the C++
-  working draft when exact wording matters, compiler-support tables before
-  assuming availability, and Compiler Explorer for generated-code claims.
-  Mark unverified claims as [unverified] and name the check that settles them.
-  Performance claims require generated code or measurements.
-  Follow CLAUDE.md conventions. Review only changed lines and behavior:
-  no speculative abstractions, drive-by cleanup, or unrelated refactors.
+  Concise, technical, no pleasantries. Fix first, then impact.
+  Ground C++ claims in cppreference or the C++ draft; mark
+  unverified claims [unverified]. Perf claims need measurements.
+  Follow CLAUDE.md. Changed lines only; no drive-by edits.
 
 reviews:
   profile: chill

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,6 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       VERSION: ${{ inputs.version }}
       NEXT_VERSION: ${{ inputs.next_version }}
-    outputs:
-      current_version: ${{ steps.project_version.outputs.current }}
     steps:
       - name: Validate input formats
         run: |
@@ -75,7 +73,6 @@ jobs:
         uses: lukka/get-cmake@v4.4.2
 
       - name: Check versions against project()
-        id: project_version
         run: |
           cmake -S . -B build/version-check -DBUILD_TESTING=OFF
           current=$(sed -n 's/^CMAKE_PROJECT_VERSION:STATIC=//p' build/version-check/CMakeCache.txt)
@@ -83,9 +80,13 @@ jobs:
             echo "::error::CMake did not report CMAKE_PROJECT_VERSION"
             exit 1
           fi
-          if [[ "${VERSION}" != "v${current}" ]]; then
-            printf "::error::release version (%s) must match CMake project version (v%s)\n" \
-              "${VERSION}" "${current}"
+          # VERSION passed the format check above, so the numeric core
+          # (the tag without any prerelease suffix) always matches.
+          [[ "${VERSION}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+) ]]
+          version_core="${BASH_REMATCH[1]}"
+          if [[ "${version_core}" != "${current}" ]]; then
+            printf "::error::release version core (%s) must match CMake project version (%s)\n" \
+              "${version_core}" "${current}"
             exit 1
           fi
           if ! printf '%s\n%s\n' "${current}" "${NEXT_VERSION}" | sort -C -V \
@@ -94,7 +95,6 @@ jobs:
               "${NEXT_VERSION}" "${current}"
             exit 1
           fi
-          echo "current=${current}" >> "${GITHUB_OUTPUT}"
 
   docker:
     name: docker
@@ -153,7 +153,7 @@ jobs:
 
   bump_cmake_version:
     name: bump cmake version via pr
-    needs: [validate, publish]
+    needs: publish
     if: >-
       !cancelled()
       && needs.publish.result == 'success'
@@ -176,6 +176,26 @@ jobs:
 
       - name: Set up CMake
         uses: lukka/get-cmake@v4.4.2
+
+      # main may have moved since validate ran (builds take ~45 min), so
+      # re-read the version from this fresh checkout: an auto-merged PR
+      # must never lower project(VERSION).
+      - name: Guard against version regression
+        id: version_guard
+        run: |
+          cmake -S . -B build/version-guard -DBUILD_TESTING=OFF
+          current=$(sed -n 's/^CMAKE_PROJECT_VERSION:STATIC=//p' build/version-guard/CMakeCache.txt)
+          if [[ -z "${current}" ]]; then
+            echo "::error::CMake did not report CMAKE_PROJECT_VERSION"
+            exit 1
+          fi
+          if ! printf '%s\n%s\n' "${current}" "${NEXT_VERSION}" | sort -C -V \
+            || [[ "${current}" == "${NEXT_VERSION}" ]]; then
+            printf "::error::next_version (%s) must be greater than the version now on main (%s) — main moved during this release\n" \
+              "${NEXT_VERSION}" "${current}"
+            exit 1
+          fi
+          echo "current_version=${current}" >> "${GITHUB_OUTPUT}"
 
       - name: Bump project version
         run: >-
@@ -211,7 +231,7 @@ jobs:
           body: |
             Post-release version bump after `${{ inputs.version }}`.
 
-            - Previous project version: `${{ needs.validate.outputs.current_version }}`
+            - Previous project version: `${{ steps.version_guard.outputs.current_version }}`
             - Next project version: `${{ inputs.next_version }}`
             - Changed file: `CMakeLists.txt`
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 #
 # One-click GitHub Release.
+#
+# Flow: validate inputs -> build packages (+ optional docker images) ->
+# create the GitHub Release -> open an auto-merged PR that bumps the
+# project() VERSION to next_version.
 name: release
 
 on:
@@ -32,8 +36,69 @@ concurrency:
 permissions: {}
 
 jobs:
+  # Fail fast on bad input before burning a full build matrix.
+  validate:
+    name: validate inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ inputs.version }}
+      NEXT_VERSION: ${{ inputs.next_version }}
+    outputs:
+      current_version: ${{ steps.project_version.outputs.current }}
+    steps:
+      - name: Validate input formats
+        run: |
+          if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::version must look like v1.2.3 or v1.2.3-rc.1 (got '${VERSION}')"
+            exit 1
+          fi
+          if [[ ! "${NEXT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::next_version must be plain semver, no v prefix (e.g. 1.0.1) — got '${NEXT_VERSION}'"
+            exit 1
+          fi
+
+      - name: Fail if tag already exists
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::tag ${VERSION} already exists"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up CMake
+        uses: lukka/get-cmake@v4.4.2
+
+      - name: Check versions against project()
+        id: project_version
+        run: |
+          cmake -S . -B build/version-check -DBUILD_TESTING=OFF
+          current=$(sed -n 's/^CMAKE_PROJECT_VERSION:STATIC=//p' build/version-check/CMakeCache.txt)
+          if [[ -z "${current}" ]]; then
+            echo "::error::CMake did not report CMAKE_PROJECT_VERSION"
+            exit 1
+          fi
+          if [[ "${VERSION}" != "v${current}" ]]; then
+            printf "::error::release version (%s) must match CMake project version (v%s)\n" \
+              "${VERSION}" "${current}"
+            exit 1
+          fi
+          if ! printf '%s\n%s\n' "${current}" "${NEXT_VERSION}" | sort -C -V \
+            || [[ "${current}" == "${NEXT_VERSION}" ]]; then
+            printf "::error::next_version (%s) must be greater than current project version (%s)\n" \
+              "${NEXT_VERSION}" "${current}"
+            exit 1
+          fi
+          echo "current=${current}" >> "${GITHUB_OUTPUT}"
+
   docker:
     name: docker
+    needs: validate
     if: ${{ inputs.publish_docker }}
     uses: ./.github/workflows/publish-docker.yml
     with:
@@ -46,37 +111,24 @@ jobs:
 
   packages:
     name: packages
+    needs: validate
     uses: ./.github/workflows/cmake_multi_platform.yml
     permissions:
       contents: read
 
   publish:
-    name: tag and github release
-    needs: [docker, packages]
+    name: github release
+    needs: [validate, docker, packages]
     if: >-
       !cancelled()
+      && needs.validate.result == 'success'
       && needs.packages.result == 'success'
       && (needs.docker.result == 'success' || needs.docker.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: write
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      VERSION: ${{ inputs.version }}
     steps:
-      - name: Validate version
-        run: |
-          if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::version must look like v1.2.3 or v1.2.3-rc.1 (got '${VERSION}')"
-            exit 1
-          fi
-          if git ls-remote --tags --exit-code "https://github.com/${{ github.repository }}.git" \
-               "refs/tags/${VERSION}" >/dev/null; then
-            echo "::error::tag ${VERSION} already exists"
-            exit 1
-          fi
-
       - name: Download release assets
         uses: actions/download-artifact@v8
         with:
@@ -84,44 +136,24 @@ jobs:
           pattern: release-assets-*
           merge-multiple: true
 
-      - name: Verify release assets
-        shell: bash
-        run: |
-          shopt -s nullglob
-          assets=(release-assets/*)
-          if (( ${#assets[@]} == 0 )); then
-            echo "::error::no release assets were downloaded"
-            exit 1
-          fi
-
-          {
-            echo "## Release assets (${#assets[@]})"
-            printf -- '- %s\n' "${assets[@]#release-assets/}"
-          } >> "${GITHUB_STEP_SUMMARY}"
-
       - name: Create GitHub Release
-        env:
-          PRERELEASE: ${{ inputs.prerelease }}
-        run: |
-          shopt -s nullglob
-          assets=(release-assets/*)
-          args=(
-            "${VERSION}"
-            --repo "${{ github.repository }}"
-            --target "${{ github.sha }}"
-            --title "${VERSION}"
-            --generate-notes
-          )
-          if [ "${PRERELEASE}" = "true" ]; then
-            args+=(--prerelease)
-          fi
-          gh release create "${args[@]}" "${assets[@]}"
-          echo "Created ${{ github.server_url }}/${{ github.repository }}/releases/tag/${VERSION}" \
-            >> "$GITHUB_STEP_SUMMARY"
+        id: release
+        uses: softprops/action-gh-release@v3.0.3
+        with:
+          tag_name: ${{ inputs.version }}
+          target_commitish: ${{ github.sha }}
+          name: ${{ inputs.version }}
+          generate_release_notes: true
+          prerelease: ${{ inputs.prerelease }}
+          fail_on_unmatched_files: true
+          files: release-assets/*
+
+      - name: Report release
+        run: echo "Created ${{ steps.release.outputs.url }}" >> "${GITHUB_STEP_SUMMARY}"
 
   bump_cmake_version:
     name: bump cmake version via pr
-    needs: publish
+    needs: [validate, publish]
     if: >-
       !cancelled()
       && needs.publish.result == 'success'
@@ -136,7 +168,6 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NEXT_VERSION: ${{ inputs.next_version }}
-      RELEASE_VERSION: ${{ inputs.version }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v7
@@ -146,35 +177,12 @@ jobs:
       - name: Set up CMake
         uses: lukka/get-cmake@v4.4.2
 
-      - name: Validate versions
-        run: |
-          if [[ ! "${NEXT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            printf "::error::next_version must be plain semver, no v prefix (e.g. 1.0.1) — got '%s'\n" "${NEXT_VERSION}"
-            exit 1
-          fi
-
-          cmake -S . -B build/version-check -DBUILD_TESTING=OFF
-          current=$(sed -n 's/^CMAKE_PROJECT_VERSION:STATIC=//p' build/version-check/CMakeCache.txt)
-          if [[ -z "${current}" ]]; then
-            echo "::error::CMake did not report CMAKE_PROJECT_VERSION"
-            exit 1
-          fi
-          if [[ "${RELEASE_VERSION}" != "v${current}" ]]; then
-            printf "::error::release version (%s) must match CMake project version (v%s)\n" \
-              "${RELEASE_VERSION}" "${current}"
-            exit 1
-          fi
-          if ! printf '%s\n%s\n' "${current}" "${NEXT_VERSION}" | sort -C -V \
-            || [[ "${current}" == "${NEXT_VERSION}" ]]; then
-            printf "::error::next_version (%s) must be greater than current project version (%s)\n" \
-              "${NEXT_VERSION}" "${current}"
-            exit 1
-          fi
-          echo "CURRENT_VERSION=${current}" >> "${GITHUB_ENV}"
-
       - name: Bump project version
-        run: |
-          cmake -DPROJECT_FILE=CMakeLists.txt -DVERSION="${NEXT_VERSION}" -P cmake/scripts/set_project_version.cmake
+        run: >-
+          cmake
+          -DPROJECT_FILE=CMakeLists.txt
+          -DVERSION="${NEXT_VERSION}"
+          -P cmake/scripts/set_project_version.cmake
 
       - name: Verify bumped project
         run: |
@@ -188,7 +196,7 @@ jobs:
           git diff --exit-code -- . ':!CMakeLists.txt'
 
       - name: Create version bump pull request
-        id: bump-pr
+        id: bump_pr
         uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -203,23 +211,23 @@ jobs:
           body: |
             Post-release version bump after `${{ inputs.version }}`.
 
-            - Previous project version: `${{ env.CURRENT_VERSION }}`
+            - Previous project version: `${{ needs.validate.outputs.current_version }}`
             - Next project version: `${{ inputs.next_version }}`
             - Changed file: `CMakeLists.txt`
 
             Generated and auto-merged by the release workflow.
 
       - name: Enable auto-merge
-        if: steps.bump-pr.outputs.pull-request-number != ''
+        if: steps.bump_pr.outputs.pull-request-number != ''
         run: >-
           gh pr merge
-          "${{ steps.bump-pr.outputs.pull-request-number }}"
+          "${{ steps.bump_pr.outputs.pull-request-number }}"
           --repo "${{ github.repository }}"
           --squash
           --auto
           --delete-branch
-          --match-head-commit "${{ steps.bump-pr.outputs.pull-request-head-sha }}"
+          --match-head-commit "${{ steps.bump_pr.outputs.pull-request-head-sha }}"
 
       - name: Report version bump
-        if: steps.bump-pr.outputs.pull-request-url != ''
-        run: echo "Opened and queued ${{ steps.bump-pr.outputs.pull-request-url }} for auto-merge" >> "${GITHUB_STEP_SUMMARY}"
+        if: steps.bump_pr.outputs.pull-request-url != ''
+        run: echo "Opened and queued ${{ steps.bump_pr.outputs.pull-request-url }} for auto-merge" >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release tag (e.g. v1.0.0)"
+        description: "Release tag (e.g. v1.0.0, or v1.0.0-rc.1 for a prerelease) — core must match project() VERSION in CMakeLists.txt"
         required: true
         type: string
       next_version:
-        description: "Next CMake project() VERSION, no v prefix (e.g. 1.0.1) — bot opens and auto-merges a PR after the release"
+        description: "Next project() VERSION, no v prefix (e.g. 1.0.1) — must exceed the current one in CMakeLists.txt; bot opens and auto-merges the bump PR"
         required: true
         type: string
       prerelease:
@@ -74,12 +74,7 @@ jobs:
 
       - name: Check versions against project()
         run: |
-          cmake -S . -B build/version-check -DBUILD_TESTING=OFF
-          current=$(sed -n 's/^CMAKE_PROJECT_VERSION:STATIC=//p' build/version-check/CMakeCache.txt)
-          if [[ -z "${current}" ]]; then
-            echo "::error::CMake did not report CMAKE_PROJECT_VERSION"
-            exit 1
-          fi
+          current=$(cmake -DPROJECT_FILE=CMakeLists.txt -P cmake/scripts/get_project_version.cmake | sed -n 's/^-- //p')
           # VERSION passed the format check above, so the numeric core
           # (the tag without any prerelease suffix) always matches.
           [[ "${VERSION}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+) ]]
@@ -183,12 +178,7 @@ jobs:
       - name: Guard against version regression
         id: version_guard
         run: |
-          cmake -S . -B build/version-guard -DBUILD_TESTING=OFF
-          current=$(sed -n 's/^CMAKE_PROJECT_VERSION:STATIC=//p' build/version-guard/CMakeCache.txt)
-          if [[ -z "${current}" ]]; then
-            echo "::error::CMake did not report CMAKE_PROJECT_VERSION"
-            exit 1
-          fi
+          current=$(cmake -DPROJECT_FILE=CMakeLists.txt -P cmake/scripts/get_project_version.cmake | sed -n 's/^-- //p')
           if ! printf '%s\n%s\n' "${current}" "${NEXT_VERSION}" | sort -C -V \
             || [[ "${current}" == "${NEXT_VERSION}" ]]; then
             printf "::error::next_version (%s) must be greater than the version now on main (%s) — main moved during this release\n" \
@@ -204,10 +194,11 @@ jobs:
           -DVERSION="${NEXT_VERSION}"
           -P cmake/scripts/set_project_version.cmake
 
+      # Getter re-read proves the rewrite; buildability of the bumped
+      # project is gated by the bump PR's own CI before auto-merge.
       - name: Verify bumped project
         run: |
-          cmake -S . -B build/version-verify -DBUILD_TESTING=OFF
-          actual=$(sed -n 's/^CMAKE_PROJECT_VERSION:STATIC=//p' build/version-verify/CMakeCache.txt)
+          actual=$(cmake -DPROJECT_FILE=CMakeLists.txt -P cmake/scripts/get_project_version.cmake | sed -n 's/^-- //p')
           test "${actual}" = "${NEXT_VERSION}" || {
             printf "::error::expected CMake project version %s, got %s\n" "${NEXT_VERSION}" "${actual}"
             exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ cmake --build build/gcc --target cpplint  # cppcheck/cpplint
 
 - Every workflow file starts with `# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json`.
 - Build matrix lives in `.github/workflows/cmake_multi_platform.yml` (`workflow_call` so `release.yml` can reuse it). Do not duplicate jobs.
-- Release is `.github/workflows/release.yml` (`workflow_dispatch`, `version` + `next_version` inputs). It pipes `publish-docker.yml` + the multi-platform workflow, then `gh release create`, then a PR that bumps `CMakeLists.txt` `project(VERSION)` and squash-merges it. Never rewrite the just-tagged version.
+- Release is `.github/workflows/release.yml` (`workflow_dispatch`, `version` + `next_version` inputs). It validates inputs, pipes `publish-docker.yml` + the multi-platform workflow, then creates the GitHub Release via `softprops/action-gh-release`, then a PR that bumps `CMakeLists.txt` `project(VERSION)` and squash-merges it. Never rewrite the just-tagged version.
 - Docker images: add a row to `publish-docker.yml` `jobs.publish.strategy.matrix.include`. No hardcoded image names — `ghcr.io/${{ github.repository }}/<name>`.
 - New matrix entries must use existing presets from `CMakePresets.json`.
 - Do NOT add platform-specific hack scripts in CI — encode logic in presets or Docker.

--- a/cmake/scripts/get_project_version.cmake
+++ b/cmake/scripts/get_project_version.cmake
@@ -1,0 +1,37 @@
+# Print the VERSION of the project() call in PROJECT_FILE to stdout.
+#
+#   cmake -DPROJECT_FILE=CMakeLists.txt -P cmake/scripts/get_project_version.cmake
+#
+# Script mode: no configure, no compiler detection, no network. Shares the
+# bracket-argument regex idiom with set_project_version.cmake — backslashes
+# reach the regex engine untouched.
+
+if(NOT DEFINED PROJECT_FILE OR PROJECT_FILE STREQUAL "")
+    message(FATAL_ERROR "PROJECT_FILE is required")
+endif()
+
+file(READ "${PROJECT_FILE}" content)
+
+# The VERSION keyword of the project() call, e.g. "VERSION 1.0.0".
+string(
+    REGEX MATCHALL
+    [==[VERSION[ \t\r\n]+[0-9]+\.[0-9]+\.[0-9]+]==]
+    version_declarations
+    "${content}")
+list(LENGTH version_declarations declaration_count)
+
+if(NOT declaration_count EQUAL 1)
+    message(
+        FATAL_ERROR
+        "expected exactly one project VERSION declaration in "
+        "${PROJECT_FILE}, found ${declaration_count}")
+endif()
+
+# Exactly one declaration: capture its version number. STATUS prints
+# "-- <version>" on stdout; callers strip the "-- " prefix.
+string(
+    REGEX MATCH
+    [==[VERSION[ \t\r\n]+([0-9]+\.[0-9]+\.[0-9]+)]==]
+    version_declaration
+    "${content}")
+message(STATUS "${CMAKE_MATCH_1}")

--- a/cmake/scripts/set_project_version.cmake
+++ b/cmake/scripts/set_project_version.cmake
@@ -1,27 +1,53 @@
+# Rewrite the VERSION field of the project() call in PROJECT_FILE.
+#
+#   cmake -DPROJECT_FILE=CMakeLists.txt -DVERSION=1.2.3 \
+#       -P cmake/scripts/set_project_version.cmake
+#
+# Every regex is a bracket argument ([==[ ]==]): backslashes reach the
+# regex engine untouched, so there is no quoted-string escaping to get
+# wrong. The previous version used "\\\\." which the regex engine saw as
+# a literal backslash followed by any character — matching nothing.
+
 if(NOT DEFINED PROJECT_FILE OR PROJECT_FILE STREQUAL "")
     message(FATAL_ERROR "PROJECT_FILE is required")
 endif()
 
-if(NOT DEFINED VERSION OR NOT VERSION MATCHES "^[0-9]+\\.[0-9]+\\.[0-9]+$")
-    message(FATAL_ERROR "VERSION must be a three-component numeric version")
+# Plain major.minor.patch, e.g. 1.2.3.
+set(version_pattern [==[[0-9]+\.[0-9]+\.[0-9]+]==])
+
+if(NOT DEFINED VERSION OR NOT VERSION MATCHES "^${version_pattern}$")
+    message(
+        FATAL_ERROR
+        "VERSION must be a three-component numeric version, got '${VERSION}'")
 endif()
 
 file(READ "${PROJECT_FILE}" content)
+
+# The VERSION keyword of the project() call, e.g. "VERSION 1.0.0".
 string(
     REGEX MATCHALL
-    "VERSION[ \t\r\n]+[0-9]+\\.[0-9]+\\.[0-9]+"
+    [==[VERSION[ \t\r\n]+[0-9]+\.[0-9]+\.[0-9]+]==]
     version_declarations
     "${content}")
 list(LENGTH version_declarations declaration_count)
 
 if(NOT declaration_count EQUAL 1)
-    message(FATAL_ERROR "expected exactly one project VERSION declaration in ${PROJECT_FILE}")
+    message(
+        FATAL_ERROR
+        "expected exactly one project VERSION declaration in "
+        "${PROJECT_FILE}, found ${declaration_count}")
 endif()
 
+# Group 1 captures the whitespace after VERSION so only the number is
+# rewritten. Replacement backreferences are single-digit (\1..\9), so
+# "\1" directly followed by the new version number is unambiguous.
 string(
     REGEX REPLACE
-    "VERSION([ \t\r\n]+)[0-9]+\\.[0-9]+\\.[0-9]+"
+    [==[VERSION([ \t\r\n]+)[0-9]+\.[0-9]+\.[0-9]+]==]
     "VERSION\\1${VERSION}"
     updated_content
     "${content}")
+
 file(WRITE "${PROJECT_FILE}" "${updated_content}")
+
+message(STATUS "set ${PROJECT_FILE} project VERSION to ${VERSION}")

--- a/cmake/scripts/stage_release_assets.cmake
+++ b/cmake/scripts/stage_release_assets.cmake
@@ -10,10 +10,13 @@ if(NOT IS_DIRECTORY "${BUILD_DIR}")
     message(FATAL_ERROR "build directory does not exist: ${BUILD_DIR}")
 endif()
 
+# Bracket argument: the regex engine sees \. as an escaped dot. A quoted
+# argument would need "\\." — the previous "\\\\." matched a literal
+# backslash plus any character, so no package ever matched.
 file(GLOB package_candidates LIST_DIRECTORIES FALSE "${BUILD_DIR}/*")
 set(package_files)
 foreach(candidate IN LISTS package_candidates)
-    if(candidate MATCHES "\\.(zip|tar\\.gz|tar\\.xz|apk)$")
+    if(candidate MATCHES [==[\.(zip|tar\.gz|tar\.xz|apk)$]==])
         list(APPEND package_files "${candidate}")
     endif()
 endforeach()


### PR DESCRIPTION
# Pull Request

## Summary
Fix the double-escaped CMake regexes (`\\\\.` matched a literal backslash, so asset staging and the version bump always failed), modernize `release.yml` around maintained actions instead of hand-rolled shell, read the `project()` version via CMake script mode — no project configure anywhere in the release flow — and repair the CodeRabbit config whose parse error made the bot ignore the entire repo configuration.

## Related Issue
No issue — release workflow fix.

## Changes
- **`cmake/scripts/set_project_version.cmake`** — all regexes rewritten as bracket arguments (`[==[ ]==]`): backslashes reach the regex engine untouched, no quoted-string escaping to get wrong. Traced against `CMakeLists.txt`: matches `VERSION 1.0.0`, correctly ignores `cmake_minimum_required(VERSION 4.4)` (two components). Header comment documents the failure mode.
- **`cmake/scripts/get_project_version.cmake`** (new) — `cmake -P` getter mirroring the setter's regex idiom and exactly-one-declaration invariant; prints the `project()` VERSION on stdout. Reading the version no longer needs a project configure (compiler detection, CPM bootstrap, network) — the read is instant.
- **`cmake/scripts/stage_release_assets.cmake`** — same escaping fix for the package filter (`\.(zip|tar\.gz|tar\.xz|apk)$`). Previously it matched nothing, so every `Stage release assets` step in CI died with `no release package found`.
- **`.github/workflows/release.yml`**:
  - New `validate` job fails fast — input formats, tag existence via `gh api` (GitHub API instead of `git ls-remote`), release tag must match `project()` VERSION, `next_version` must be newer — **before** the build matrix and docker images burn ~45 min. This also removes the validation logic that was duplicated between `publish` and `bump_cmake_version`.
  - All version reads (`validate`, `version_guard`, post-bump verify) use `get_project_version.cmake` — zero `cmake -S . -B` configures remain in the workflow. Buildability of the bumped project stays gated by the bump PR's own CI before auto-merge.
  - Hand-rolled `gh release create` bash replaced with `softprops/action-gh-release@v3.0.3` (tag creation at `target_commitish`, generated notes, prerelease flag, asset glob upload). `fail_on_unmatched_files: true` makes the custom asset-verification step redundant — removed.
  - Input descriptions now hint that the current version lives in `CMakeLists.txt` `project()` (dispatch inputs can't have dynamic defaults).
  - snake_case step ids / outputs: `bump_pr`, `version_guard`.
- **`.coderabbit.yaml`** — `tone_instructions` was ~570 chars against the schema's 250-char cap, so CodeRabbit rejected the **whole config** and ran on defaults (profile, path instructions, tool toggles silently ignored). Compressed to 237 chars keeping all seven directives; rest of the file untouched.
- **`CLAUDE.md`** — one-line doc sync: `gh release create` → `softprops/action-gh-release`.

### Review follow-ups (CodeRabbit, commit `f464a2d`)
- **Prerelease tags validate correctly** — the format check accepted `v1.2.3-rc.1` but the equality check compared the full tag against the numeric project version, so every prerelease release failed. The numeric core (`BASH_REMATCH`) is now compared against `project()` VERSION; prereleases of the current version pass.
- **Bump job guards against `main` drift** — `validate` runs ~45 min before the bump job checks out `main`; a merge in between could have turned `next_version` into a downgrade that auto-merge would ship unreviewed. The bump job re-reads `project()` VERSION from the fresh checkout (via the getter) and fails unless `next_version` is strictly greater, before rewriting. The bump PR body uses this fresh value.

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes — N/A, no C++/preset changes
- [ ] `cmake --workflow --preset=gcc-full` passes — N/A, no packaging/preset changes
- [ ] `pre-commit run --all-files` passes — worth running locally; cmake-format style (80 col, dangle parens) was followed but not machine-verified
- [ ] Affected cross-compilation presets tested — N/A
- [x] Documentation updated (`CLAUDE.md` release-flow line)
- [ ] `docker build` succeeds — N/A, no Dockerfile changes

Manual smoke test before the next release:
```bash
cmake -DPROJECT_FILE=CMakeLists.txt -P cmake/scripts/get_project_version.cmake   # expect: -- 1.0.0
cmake -DPROJECT_FILE=CMakeLists.txt -DVERSION=1.0.1 -P cmake/scripts/set_project_version.cmake
git diff   # expect only the VERSION line to change; then git checkout -- CMakeLists.txt
```

## Notes for Reviewer
- The setter's replacement string `"VERSION\\1${VERSION}"` relies on CMake replacement backreferences being single-digit (`\1`..`\9`), so `\1` followed by a version starting with a digit is unambiguous — documented in a script comment.
- The getter prints via `message(STATUS ...)`, which prefixes stdout lines with `-- `; callers strip it with `sed -n 's/^-- //p'`. `cmake -P` emits nothing else on stdout, and a `FATAL_ERROR` exits non-zero (pipeline fails under `pipefail`), so no empty-version guard is needed in bash.
- `softprops/action-gh-release` v2 is EOL (Node 20 runtime deprecated); pinned `v3.0.3` (Node 24), matching the repo's exact-tag pinning for third-party actions. Renovate will track it.
- The `.coderabbit.yaml` fix takes effect for reviews once merged to the default branch (CodeRabbit reads config from the repo root there); this PR may still be reviewed under defaults.
- Both CodeRabbit findings were verified against the code before fixing — see resolved threads for the analysis.
- Opened per request — **not merged**; review and merge when ready.