### PR TITLE
fix(android): serialize SDL3 export across parallel ABI configures (root cause of missing test reports)

### DIFF
--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -334,9 +334,25 @@ jobs:
           target: default
           disable-animations: true
           script: cd ${{ env.ANDROID_PROJECT_DIR }} && ./gradlew --stacktrace :app:connectedDebugAndroidTest --info
-      # Runs under `if: always()`: when the emulator step fails before AGP
-      # produces reports (build error, boot failure) nothing exists to upload,
-      # so warn instead of erroring — the test step already decides the job.
+      # Diagnostics for the upload below: when the test step fails before AGP
+      # writes reports (build error, emulator boot failure) the upload errors
+      # with a bare "no files found" — this step shows what actually exists.
+      - name: Locate test reports
+        if: always()
+        shell: bash
+        run: |
+          build_dir="${{ env.ANDROID_PROJECT_DIR }}/app/build"
+          for dir in outputs/androidTest-results reports/androidTests; do
+            path="${build_dir}/${dir}"
+            if [ -d "${path}" ]; then
+              echo "== ${dir} =="
+              find "${path}" -type f | sort
+            else
+              echo "::warning::${dir} not found under app/build"
+            fi
+          done
+      # Strict on purpose: a completed test run must produce reports. If this
+      # errors, the step above shows where AGP actually wrote them.
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -345,5 +361,5 @@ jobs:
           path: |
             ${{ env.ANDROID_PROJECT_DIR }}/app/build/outputs/androidTest-results/
             ${{ env.ANDROID_PROJECT_DIR }}/app/build/reports/androidTests/
-          if-no-files-found: warn
+          if-no-files-found: error
           compression-level: 0

--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -334,6 +334,9 @@ jobs:
           target: default
           disable-animations: true
           script: cd ${{ env.ANDROID_PROJECT_DIR }} && ./gradlew --stacktrace :app:connectedDebugAndroidTest --info
+      # Runs under `if: always()`: when the emulator step fails before AGP
+      # produces reports (build error, boot failure) nothing exists to upload,
+      # so warn instead of erroring — the test step already decides the job.
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -342,5 +345,5 @@ jobs:
           path: |
             ${{ env.ANDROID_PROJECT_DIR }}/app/build/outputs/androidTest-results/
             ${{ env.ANDROID_PROJECT_DIR }}/app/build/reports/androidTests/
-          if-no-files-found: error
+          if-no-files-found: warn
           compression-level: 0

--- a/cmake/cpm/sdl3-config.cmake
+++ b/cmake/cpm/sdl3-config.cmake
@@ -89,6 +89,15 @@ cpmaddpackage(
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")
     set(ct_sdl3_gen
         "${CMAKE_SOURCE_DIR}/android_project/app/build/generated/sdl3")
+    # AGP runs one CMake configure per ABI concurrently — every configure
+    # exports into this same directory. Concurrent file(COPY) into a shared
+    # destination fails intermittently with "file COPY cannot set permissions
+    # on ...: No such file or directory", so serialize the export across
+    # configure processes. GUARD PROCESS releases the lock when this
+    # configure ends, even on error; without RESULT_VARIABLE a timeout is a
+    # hard error instead of silent corruption.
+    file(MAKE_DIRECTORY "${ct_sdl3_gen}")
+    file(LOCK "${ct_sdl3_gen}" DIRECTORY GUARD PROCESS TIMEOUT 600)
     file(
         COPY "${SDL3_SOURCE_DIR}/android-project/app/src/main/java/org/"
         DESTINATION "${ct_sdl3_gen}/java/org"


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the flaky android CI failure whose final symptom was `upload-artifact` erroring with `No files were found with the provided path: .../app/build/outputs/androidTest-results/ .../app/build/reports/androidTests/` — the root cause is a race between AGP's parallel per-ABI CMake configures both exporting SDL3 Java bindings into the same shared directory.

## Related Issue
No issue — CI fix.

## Root cause (from the failing job log)

```
CMake Error at cmake/cpm/sdl3-config.cmake:92 (file):
  file COPY cannot set permissions on
  ".../app/build/generated/sdl3/java/org/libsdl/app/SDLDummyEdit.java":
  No such file or directory.
...
BUILD FAILED in 52s — ExternalNativeBuildJsonTask
```

Failure chain:

1. AGP runs **one CMake configure per ABI** (`configureCMakeRelWithDebInfo[arm64-v8a]`, `[x86_64]`) **concurrently** — `org.gradle.parallel=true` in `android_project/gradle.properties` and `GRADLE_OPTS=-Dorg.gradle.parallel=true` in the workflow.
2. Every configure executes `cmake/cpm/sdl3-config.cmake`, which `file(COPY)`s SDL's Java bindings into the **same shared directory** `android_project/app/build/generated/sdl3/`.
3. Two concurrent `file(COPY)` calls into one destination race: one process sets permissions on a file the other is mid-rewrite on → intermittent `file COPY cannot set permissions on ...: No such file or directory`. Same failure signature (intermittent, different file each run) reported upstream: https://discourse.cmake.org/t/file-copy-error-claiming-files-do-not-exist-or-are-unmodifiable/15193 — and the same parallel-Gradle/shared-output race class is documented in https://github.com/android/ndk-samples/pull/1167
4. Configure fails → `ExternalNativeBuildJsonTask` fails → `BUILD FAILED` → `connectedDebugAndroidTest` never runs → **no test reports are ever written** → the `if: always()` upload step errors with "No files were found".

The flakiness (same commit green on one run, red on the next) is the race — this is why the emulator job passed on this PR's first run while failing elsewhere.

## Changes
- `cmake/cpm/sdl3-config.cmake` — the fix: `file(MAKE_DIRECTORY)` + `file(LOCK <dir> DIRECTORY GUARD PROCESS TIMEOUT 600)` around the SDL3 export. Serializes the copy across concurrent configure processes; `GUARD PROCESS` releases the lock when the configure ends even on error; no `RESULT_VARIABLE` so a timeout is a hard error, not silent corruption. `file(COPY)` already skips up-to-date files, so the second configure's export under the lock is a cheap no-op.
- `.github/workflows/cmake_multi_platform.yml` — `android_instrumented_test` job: adds a never-failing **Locate test reports** step that lists what AGP actually produced, so any future upload error is diagnosable from the job log. The upload stays strict: `if: always()` + `if-no-files-found: error` — a completed test run must produce reports.

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed

Real verification is this PR's CI: `android_gradle_x86_64` and `android_emulator_x86_64` both exercise the previously-racing configure path and must go green with the strict upload. Note the race is timing-dependent, so a single green run is necessary-but-not-sufficient evidence — the lock is the actual guarantee. Recommend re-running the workflow once or twice before merging.

## Notes for Reviewer
- Earlier commits on this branch experimented with downgrading the upload to `warn`; reverted — strictness stays, per review.
- Alternative fixes considered and rejected: per-ABI export directories (requires touching `sourceSets` in `app/build.gradle`, more invasive); moving the export into a Gradle task (larger change, duplicates CMake-side logic). The lock is 2 lines and fixes the race at the exact point of contention.
- Do not merge until the android jobs have completed on the latest commit.