### PR TITLE
build(android): disable Gradle parallelism, drop deprecated AGP properties

### DIFF
--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -48,7 +48,6 @@ env:
   ANDROID_PROJECT_DIR: ${{ github.workspace }}/android_project
   GRADLE_OPTS: >-
     -Dorg.gradle.daemon=false
-    -Dorg.gradle.parallel=true
     -Dorg.gradle.configureondemand=true
 
 jobs:

--- a/android_project/gradle.properties
+++ b/android_project/gradle.properties
@@ -12,7 +12,6 @@
 # org.gradle.parallel=true
 #Tue Jun 27 20:52:28 MSK 2023
 org.gradle.jvmargs=-Xmx4g -XX:+UseG1GC -Dfile.encoding=UTF-8
-org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 android.useAndroidX=true

--- a/android_project/gradle.properties
+++ b/android_project/gradle.properties
@@ -18,16 +18,11 @@ android.useAndroidX=true
 android.nonTransitiveRClass=true
 
 org.gradle.warning.mode=all
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
+# Recommended by AGP: improves project import/sync performance
+android.dependency.excludeLibraryComponentsFromConstraints=true
 android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false
 
 # Enabled parallel sync for Gradle 9.4+
 org.gradle.tooling.parallel=true

--- a/cmake/cpm/sdl3-config.cmake
+++ b/cmake/cpm/sdl3-config.cmake
@@ -89,15 +89,6 @@ cpmaddpackage(
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")
     set(ct_sdl3_gen
         "${CMAKE_SOURCE_DIR}/android_project/app/build/generated/sdl3")
-    # AGP runs one CMake configure per ABI concurrently — every configure
-    # exports into this same directory. Concurrent file(COPY) into a shared
-    # destination fails intermittently with "file COPY cannot set permissions
-    # on ...: No such file or directory", so serialize the export across
-    # configure processes. GUARD PROCESS releases the lock when this
-    # configure ends, even on error; without RESULT_VARIABLE a timeout is a
-    # hard error instead of silent corruption.
-    file(MAKE_DIRECTORY "${ct_sdl3_gen}")
-    file(LOCK "${ct_sdl3_gen}" DIRECTORY GUARD PROCESS TIMEOUT 600)
     file(
         COPY "${SDL3_SOURCE_DIR}/android-project/app/src/main/java/org/"
         DESTINATION "${ct_sdl3_gen}/java/org"


### PR DESCRIPTION
# Pull Request

## Summary
Two-part android build hygiene: (1) alternative to the merged #83 — fixes the flaky SDL3 export race (`file COPY cannot set permissions on .../generated/sdl3/...: No such file or directory`) by removing Gradle parallelism instead of locking; (2) cleans up all deprecated AGP properties that spam warnings on every build and become hard errors in AGP 10.0.

## Related Issue
No issue — CI/build fix. Supersedes the approach merged in #83.

## Changes

**Race fix (commit da5b820):**
- `android_project/gradle.properties` — drop `org.gradle.parallel=true`
- `.github/workflows/cmake_multi_platform.yml` — drop `-Dorg.gradle.parallel=true` from `GRADLE_OPTS` (keeps `daemon=false`, `configureondemand=true`)
- `cmake/cpm/sdl3-config.cmake` — revert the `file(LOCK)` guard added in #83 (export block back to the original copy)

Rationale: the race needs two CMake configures running concurrently against the shared `app/build/generated/sdl3/` directory. With Gradle parallelism off, per-ABI configure tasks are serialized — one writer at a time, no lock needed.

**Deprecation cleanup (commit d70830f)** — all in `android_project/gradle.properties`. Each removed property is deprecated in AGP 9.x, warns per build, and is removed in AGP 10.0; the current defaults are already the opposite values, so the lines only pinned legacy behavior:

| Removed property | Why safe |
| --- | --- |
| `android.usesSdkInManifest.disallowed=false` | Manifest has no `package` attribute and no `<uses-sdk>` (verified); DSL `namespace` is used |
| `android.sdk.defaultTargetSdkToCompileSdkIfUnset=false` | `targetSdk = 37` set explicitly in `defaultConfig` |
| `android.enableAppCompileTimeRClass=false` | Complements already-set `nonTransitiveRClass=true`; SDL's Java bindings resolve resources via `getIdentifier()`, no R coupling |
| `android.builtInKotlin=false` | Module has no Kotlin sources |
| `android.newDsl=false` | `build.gradle` uses standard DSL blocks; CI evaluates the full file |
| `android.r8.optimizedResourceShrinking=false` | Optimized shrinking is the better release default |
| `android.defaults.buildfeatures.resvalues=true` | No `resValue` DSL calls exist — feature unused |

Also **added** `android.dependency.excludeLibraryComponentsFromConstraints=true` — the fix AGP itself recommends for the sync-performance warning, instead of suppressing it.

Not done on purpose: no `android.sync.suppressAgpWarnings=...` — that flag only hides the warnings until AGP 10.0 turns them into errors.

Deliberately untouched: `org.gradle.tooling.parallel=true` (IDE sync parallelism, not build scheduling), `android.uniquePackageNames=false`, `android.dependency.useConstraints=true`, `android.r8.strictFullModeForKeepRules=false` (none deprecated), plus the "Locate test reports" step and strict `if-no-files-found: error` upload from #83.

## Verification
- [ ] `cmake --preset=gcc && cmake --build --preset=gcc-release && ctest --preset=gcc-release` passes
- [ ] `cmake --workflow --preset=gcc-full` passes (if affecting packaging/presets)
- [ ] `pre-commit run --all-files` passes (formatting, lint)
- [ ] Affected cross-compilation presets tested (if applicable: `llvm-mingw-*`, `android-*`)
- [ ] Documentation updated (`docs/*.md`, `README.md` comparison table if adding features)
- [ ] `docker build` succeeds if Dockerfiles changed

Real verification is this PR's CI: `android_gradle_x86_64` and `android_emulator_x86_64` evaluate the full `build.gradle` DSL under the new defaults and exercise the previously-racing configure path. The Gradle log should show zero `WARNING: The option setting ...` lines.

## Notes for Reviewer
- **Race-fix caveat**: `org.gradle.parallel` parallelizes across *projects* and this is a single-module build (`:app` only) — cost of removal is ~zero, but if AGP 9.3 spawns per-ABI CMake configures on its own threads, the race can still occur. If `file COPY cannot set permissions` reappears, re-apply the lock from #83 (commit 9e7ab0c) — that fix works regardless of who schedules the configures.
- **Race is timing-dependent**: one green run is evidence, not proof. Re-run the android jobs 2–3 times before considering it closed.
- **Deprecation cleanup changes behavior to current defaults** — that's the point (AGP 10.0 will force them anyway), and this PR's android CI jobs are the regression net. `newDsl=true` is the highest-risk flip; if the DSL evaluation breaks, the log will show it immediately at configuration time.
- Do not merge until the android jobs complete on the latest commit.